### PR TITLE
Add `template` command

### DIFF
--- a/data/configure.yaml
+++ b/data/configure.yaml
@@ -82,8 +82,6 @@ group:
   - *network2_defined
   - *network3_defined
 
-node:
-  # BASE
-  - *hostname_range
+node: []
 
 local: []

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -261,6 +261,26 @@ commands:
       group: *render_group
       node: *render_node
 
+  template:
+    syntax: underware template [options]
+    summary: Render all Underware templates for all platforms
+    description: >
+      This command renders all the templates provided by Underware for every
+      combination of platform and scope that this installation of Underware is
+      configured with.
+
+
+      Specifically this consists of rendering, for every platform, the
+      available domain, group, and node templates (both platform-specific and
+      platform-independent content), for the domain, every group, and every
+      node respectively.
+
+
+      The rendered templates can then be used, on their own or in combination
+      with other Alces tools, to deploy, configure, or otherwise manage, a
+      cluster at different scales and across different platforms.
+    action: Commands::Template
+
   view-answers:
     syntax: underware view-answers [SUB_COMMAND] [options]
     summary: View configured answers

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -90,7 +90,7 @@ module Underware
       end
 
       def class_name_parts
-        self.class.name.split('::').map(&:downcase).map(&:to_sym)
+        Utils.class_name_parts(self)
       end
 
       def alces

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -39,18 +39,17 @@ module Underware
           platform_group_templates = templates_in_dir(platform, scope_type: :group)
 
           group_templates = content_group_templates + platform_group_templates
-          GroupCache.new.each do |group|
-            group_namespace = platform_alces.groups.find_by_name(group)
+          platform_alces.groups.each do |group|
             group_templates.each do |template|
               relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
 
               relative_rendered_path = relative_path
                 .sub(/^#{CONTENT_NAME}/, platform)
-                .sub('group', "group/#{group}")
+                .sub('group', "group/#{group.name}")
               rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
               FileUtils.mkdir_p rendered_path.dirname
 
-              rendered_template = group_namespace.render_file(template)
+              rendered_template = group.render_file(template)
               File.write(rendered_path, rendered_template)
             end
           end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -4,28 +4,42 @@ module Underware
     class Template < CommandHelpers::BaseCommand
       private
 
+      # Directory name where shared 'content' templates live.
+      CONTENT_NAME = 'content'
+
       def run
         platforms_glob = "#{FilePath.platform_configs_dir}/*.yaml"
         platforms = Pathname.glob(platforms_glob).map do |config_path|
           config_path.basename.sub_ext('').to_s
         end
 
+        content_domain_templates = domain_templates_in_dir(CONTENT_NAME)
+
         platforms.each do |platform|
           platform_alces = Namespaces::Alces.new(platform: platform)
+          platform_domain_templates = domain_templates_in_dir(platform)
 
-          domain_templates_glob = "#{FilePath.templates_dir}/#{platform}/domain/*"
-          domain_templates = Pathname.glob(domain_templates_glob)
-
+          domain_templates = content_domain_templates + platform_domain_templates
           domain_templates.each do |template|
             relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
 
-            rendered_path = Pathname.new(FilePath.rendered).join(relative_path)
+            # Content templates should be rendered once for each platform, to
+            # platform-specific directory, therefore if template path begins
+            # with 'content' directory this should be replaced with platform
+            # name in rendered path.
+            relative_rendered_path = relative_path.sub(/^#{CONTENT_NAME}/, platform)
+            rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
             FileUtils.mkdir_p rendered_path.dirname
 
             rendered_template = platform_alces.render_file(template)
             File.write(rendered_path, rendered_template)
           end
         end
+      end
+
+      def domain_templates_in_dir(templates_dir_name)
+        glob = "#{FilePath.templates_dir}/#{templates_dir_name}/domain/*"
+        Pathname.glob(glob)
       end
     end
   end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -13,11 +13,11 @@ module Underware
           config_path.basename.sub_ext('').to_s
         end
 
-        content_domain_templates = domain_templates_in_dir(CONTENT_NAME)
+        content_domain_templates = templates_in_dir(CONTENT_NAME, scope_type: :domain)
 
         platforms.each do |platform|
           platform_alces = Namespaces::Alces.new(platform: platform)
-          platform_domain_templates = domain_templates_in_dir(platform)
+          platform_domain_templates = templates_in_dir(platform, scope_type: :domain)
 
           domain_templates = content_domain_templates + platform_domain_templates
           domain_templates.each do |template|
@@ -34,11 +34,27 @@ module Underware
             rendered_template = platform_alces.render_file(template)
             File.write(rendered_path, rendered_template)
           end
+
+          platform_group_templates = templates_in_dir(platform, scope_type: :group)
+          GroupCache.new.each do |group|
+            platform_group_templates.each do |template|
+              relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
+
+              relative_rendered_path = relative_path
+                .sub(/^#{CONTENT_NAME}/, platform)
+                .sub('group', "group/#{group}")
+              rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
+              FileUtils.mkdir_p rendered_path.dirname
+
+              rendered_template = platform_alces.render_file(template)
+              File.write(rendered_path, rendered_template)
+            end
+          end
         end
       end
 
-      def domain_templates_in_dir(templates_dir_name)
-        glob = "#{FilePath.templates_dir}/#{templates_dir_name}/domain/*"
+      def templates_in_dir(templates_dir_name, scope_type:)
+        glob = "#{FilePath.templates_dir}/#{templates_dir_name}/#{scope_type}/*"
         Pathname.glob(glob)
       end
     end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -87,8 +87,8 @@ module Underware
       end
 
       def templates_in_dir(templates_dir_name, scope_type:)
-        glob = "#{FilePath.templates_dir}/#{templates_dir_name}/#{scope_type}/*"
-        Pathname.glob(glob)
+        glob = "#{FilePath.templates_dir}/#{templates_dir_name}/#{scope_type}/**/*"
+        Pathname.glob(glob).select(&:file?)
       end
     end
   end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -15,6 +15,7 @@ module Underware
 
         content_domain_templates = templates_in_dir(CONTENT_NAME, scope_type: :domain)
         content_group_templates = templates_in_dir(CONTENT_NAME, scope_type: :group)
+        content_node_templates = templates_in_dir(CONTENT_NAME, scope_type: :node)
 
         platforms.each do |platform|
           platform_alces = Namespaces::Alces.new(platform: platform)
@@ -50,6 +51,24 @@ module Underware
               FileUtils.mkdir_p rendered_path.dirname
 
               rendered_template = group.render_file(template)
+              File.write(rendered_path, rendered_template)
+            end
+          end
+
+          platform_node_templates = templates_in_dir(platform, scope_type: :node)
+
+          node_templates = content_node_templates + platform_node_templates
+          platform_alces.nodes.each do |node|
+            node_templates.each do |template|
+              relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
+
+              relative_rendered_path = relative_path
+                .sub(/^#{CONTENT_NAME}/, platform)
+                .sub('node', "node/#{node.name}")
+              rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
+              FileUtils.mkdir_p rendered_path.dirname
+
+              rendered_template = node.render_file(template)
               File.write(rendered_path, rendered_template)
             end
           end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -1,0 +1,25 @@
+
+module Underware
+  module Commands
+    class Template < CommandHelpers::BaseCommand
+      private
+
+      def run
+        domain_templates_glob = "#{FilePath.templates_dir}/*/domain/*"
+        domain_templates = Pathname.glob(domain_templates_glob)
+        domain_templates.each do |template|
+          relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
+
+          rendered_path = Pathname.new(FilePath.rendered).join(relative_path)
+          FileUtils.mkdir_p rendered_path.dirname
+
+          platform = relative_path.to_s.split(File::SEPARATOR).first
+          # XXX Stop recreating new Alces for every template.
+          platform_alces = Namespaces::Alces.new(platform: platform)
+          rendered_template = platform_alces.render_file(template)
+          File.write(rendered_path, rendered_template)
+        end
+      end
+    end
+  end
+end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -7,7 +7,18 @@ module Underware
       # Directory name where shared 'content' templates live.
       CONTENT_NAME = 'content'
 
+      # Rendered file directories to preserve when `template` is run (all other
+      # directories will be cleared out on each `template` run, so that only
+      # latest rendered files are present).
+      PRESERVE_RENDERED_DIRS = [Constants::RENDERED_SYSTEM_FILES_PATH]
+
       def run
+        Pathname.new(FilePath.rendered).children.map(&:to_s).each do |rendered_dir|
+          unless PRESERVE_RENDERED_DIRS.include?(rendered_dir)
+            FileUtils.rm_rf(rendered_dir)
+          end
+        end
+
         platforms_glob = "#{FilePath.platform_configs_dir}/*.yaml"
         platforms = Pathname.glob(platforms_glob).map do |config_path|
           config_path.basename.sub_ext('').to_s

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -40,6 +40,7 @@ module Underware
 
           group_templates = content_group_templates + platform_group_templates
           GroupCache.new.each do |group|
+            group_namespace = platform_alces.groups.find_by_name(group)
             group_templates.each do |template|
               relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
 
@@ -49,7 +50,7 @@ module Underware
               rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
               FileUtils.mkdir_p rendered_path.dirname
 
-              rendered_template = platform_alces.render_file(template)
+              rendered_template = group_namespace.render_file(template)
               File.write(rendered_path, rendered_template)
             end
           end

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -14,6 +14,7 @@ module Underware
         end
 
         content_domain_templates = templates_in_dir(CONTENT_NAME, scope_type: :domain)
+        content_group_templates = templates_in_dir(CONTENT_NAME, scope_type: :group)
 
         platforms.each do |platform|
           platform_alces = Namespaces::Alces.new(platform: platform)
@@ -36,8 +37,10 @@ module Underware
           end
 
           platform_group_templates = templates_in_dir(platform, scope_type: :group)
+
+          group_templates = content_group_templates + platform_group_templates
           GroupCache.new.each do |group|
-            platform_group_templates.each do |template|
+            group_templates.each do |template|
               relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
 
               relative_rendered_path = relative_path

--- a/lib/underware/commands/template.rb
+++ b/lib/underware/commands/template.rb
@@ -1,11 +1,10 @@
 
+require 'underware/platform'
+
 module Underware
   module Commands
     class Template < CommandHelpers::BaseCommand
       private
-
-      # Directory name where shared 'content' templates live.
-      CONTENT_NAME = 'content'
 
       # Rendered file directories to preserve when `template` is run (all other
       # directories will be cleared out on each `template` run, so that only
@@ -13,82 +12,16 @@ module Underware
       PRESERVE_RENDERED_DIRS = [Constants::RENDERED_SYSTEM_FILES_PATH]
 
       def run
+        clear_current_rendered_dir
+        Platform.all.each(&:render_templates)
+      end
+
+      def clear_current_rendered_dir
         Pathname.new(FilePath.rendered).children.map(&:to_s).each do |rendered_dir|
           unless PRESERVE_RENDERED_DIRS.include?(rendered_dir)
             FileUtils.rm_rf(rendered_dir)
           end
         end
-
-        platforms_glob = "#{FilePath.platform_configs_dir}/*.yaml"
-        platforms = Pathname.glob(platforms_glob).map do |config_path|
-          config_path.basename.sub_ext('').to_s
-        end
-
-        content_domain_templates = templates_in_dir(CONTENT_NAME, scope_type: :domain)
-        content_group_templates = templates_in_dir(CONTENT_NAME, scope_type: :group)
-        content_node_templates = templates_in_dir(CONTENT_NAME, scope_type: :node)
-
-        platforms.each do |platform|
-          platform_alces = Namespaces::Alces.new(platform: platform)
-          platform_domain_templates = templates_in_dir(platform, scope_type: :domain)
-
-          domain_templates = content_domain_templates + platform_domain_templates
-          domain_templates.each do |template|
-            relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
-
-            # Content templates should be rendered once for each platform, to
-            # platform-specific directory, therefore if template path begins
-            # with 'content' directory this should be replaced with platform
-            # name in rendered path.
-            relative_rendered_path = relative_path.sub(/^#{CONTENT_NAME}/, platform)
-            rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
-            FileUtils.mkdir_p rendered_path.dirname
-
-            rendered_template = platform_alces.render_file(template)
-            File.write(rendered_path, rendered_template)
-          end
-
-          platform_group_templates = templates_in_dir(platform, scope_type: :group)
-
-          group_templates = content_group_templates + platform_group_templates
-          platform_alces.groups.each do |group|
-            group_templates.each do |template|
-              relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
-
-              relative_rendered_path = relative_path
-                .sub(/^#{CONTENT_NAME}/, platform)
-                .sub('group', "group/#{group.name}")
-              rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
-              FileUtils.mkdir_p rendered_path.dirname
-
-              rendered_template = group.render_file(template)
-              File.write(rendered_path, rendered_template)
-            end
-          end
-
-          platform_node_templates = templates_in_dir(platform, scope_type: :node)
-
-          node_templates = content_node_templates + platform_node_templates
-          platform_alces.nodes.each do |node|
-            node_templates.each do |template|
-              relative_path = template.relative_path_from(Pathname.new(FilePath.templates_dir))
-
-              relative_rendered_path = relative_path
-                .sub(/^#{CONTENT_NAME}/, platform)
-                .sub('node', "node/#{node.name}")
-              rendered_path = Pathname.new(FilePath.rendered).join(relative_rendered_path)
-              FileUtils.mkdir_p rendered_path.dirname
-
-              rendered_template = node.render_file(template)
-              File.write(rendered_path, rendered_template)
-            end
-          end
-        end
-      end
-
-      def templates_in_dir(templates_dir_name, scope_type:)
-        glob = "#{FilePath.templates_dir}/#{templates_dir_name}/#{scope_type}/**/*"
-        Pathname.glob(glob).select(&:file?)
       end
     end
   end

--- a/lib/underware/constants.rb
+++ b/lib/underware/constants.rb
@@ -32,7 +32,8 @@ module Underware
     UNDERWARE_STORAGE_PATH = '/var/lib/underware'
     NAMESPACE_DATA_PATH = File.join(UNDERWARE_STORAGE_PATH, 'data')
     RENDERED_PATH = File.join(UNDERWARE_STORAGE_PATH, 'rendered')
-    GENDERS_PATH = File.join(RENDERED_PATH, 'system/genders')
+    RENDERED_SYSTEM_FILES_PATH = File.join(RENDERED_PATH, 'system')
+    GENDERS_PATH = File.join(RENDERED_SYSTEM_FILES_PATH, 'genders')
 
     CACHE_PATH = File.join(UNDERWARE_STORAGE_PATH, 'cache')
     GROUP_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')

--- a/lib/underware/constants.rb
+++ b/lib/underware/constants.rb
@@ -35,6 +35,9 @@ module Underware
     RENDERED_SYSTEM_FILES_PATH = File.join(RENDERED_PATH, 'system')
     GENDERS_PATH = File.join(RENDERED_SYSTEM_FILES_PATH, 'genders')
 
+    # Directory name where shared 'content' templates live.
+    CONTENT_DIR_NAME = 'content'
+
     CACHE_PATH = File.join(UNDERWARE_STORAGE_PATH, 'cache')
     GROUP_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')
     PLUGINS_CACHE_PATH = File.join(CACHE_PATH, 'plugins.yaml')

--- a/lib/underware/constants.rb
+++ b/lib/underware/constants.rb
@@ -31,10 +31,8 @@ module Underware
 
     UNDERWARE_STORAGE_PATH = '/var/lib/underware'
     NAMESPACE_DATA_PATH = File.join(UNDERWARE_STORAGE_PATH, 'data')
-    # Genders is now (at least as of right now) the only file rendered
-    # internally by Underware itself, and so will now be the only file within
-    # `/var/lib/underware/rendered`.
-    GENDERS_PATH = File.join(UNDERWARE_STORAGE_PATH, 'rendered/system/genders')
+    RENDERED_PATH = File.join(UNDERWARE_STORAGE_PATH, 'rendered')
+    GENDERS_PATH = File.join(RENDERED_PATH, 'system/genders')
 
     CACHE_PATH = File.join(UNDERWARE_STORAGE_PATH, 'cache')
     GROUP_CACHE_PATH = File.join(CACHE_PATH, 'groups.yaml')

--- a/lib/underware/file_path.rb
+++ b/lib/underware/file_path.rb
@@ -137,7 +137,11 @@ module Underware
       end
 
       def platform_config(platform)
-        File.join(config_dir, 'platforms', "#{platform}.yaml")
+        File.join(platform_configs_dir, "#{platform}.yaml")
+      end
+
+      def platform_configs_dir
+        File.join(config_dir, 'platforms')
       end
 
       private

--- a/lib/underware/namespaces/hash_merger_namespace.rb
+++ b/lib/underware/namespaces/hash_merger_namespace.rb
@@ -40,6 +40,10 @@ module Underware
         )
       end
 
+      def scope_type
+        Utils.class_name_parts(self).last
+      end
+
       private
 
       attr_reader :alces

--- a/lib/underware/platform.rb
+++ b/lib/underware/platform.rb
@@ -1,0 +1,51 @@
+
+require 'underware/template'
+
+module Underware
+  Platform = Struct.new(:name) do
+    def self.all
+      platforms_glob = "#{FilePath.platform_configs_dir}/*.yaml"
+      Pathname.glob(platforms_glob).map do |config_path|
+        name = config_path.basename.sub_ext('').to_s
+        new(name)
+      end
+    end
+
+    def render_templates
+      namespaces.each do |namespace|
+        render_templates_for_namespace(namespace)
+      end
+    end
+
+    private
+
+    def namespaces
+       [alces.domain] + alces.groups + alces.nodes
+    end
+
+    def alces
+      @alces ||= Namespaces::Alces.new(platform: name)
+    end
+
+    def render_templates_for_namespace(namespace)
+      scope_type = namespace.scope_type
+      templates = platform_templates[scope_type] + content_templates[scope_type]
+      templates.each { |template| template.render_for(namespace) }
+    end
+
+    def platform_templates
+      # We cache this so we only load the platform templates once when a single
+      # Platform instance is reused to render for multiple namespaces.
+      @platform_templates ||=
+        Template.all_under_directory(name)
+    end
+
+    def content_templates
+      # Similarly cache this, though since content templates are shared between
+      # platforms these may still be loaded multiple times, once per Platform
+      # instance which is rendered against.
+      @content_templates ||=
+        Template.all_under_directory(Constants::CONTENT_DIR_NAME)
+    end
+  end
+end

--- a/lib/underware/template.rb
+++ b/lib/underware/template.rb
@@ -1,0 +1,60 @@
+
+module Underware
+  Template = Struct.new(:template_path) do
+    TEMPLATES_DIR_PATH = Pathname.new(FilePath.templates_dir)
+
+    class << self
+      def all_under_directory(templates_dir_name)
+        [:domain, :group, :node].map do |scope_type|
+          [
+            scope_type,
+            templates_in_dir(templates_dir_name, scope_type: scope_type)
+          ]
+        end.to_h
+      end
+
+      private
+
+      def templates_in_dir(templates_dir_name, scope_type:)
+        glob = "#{TEMPLATES_DIR_PATH}/#{templates_dir_name}/#{scope_type}/**/*"
+        Pathname.glob(glob).select(&:file?).map do |template_path|
+          new(template_path)
+        end
+      end
+    end
+
+    def render_for(namespace)
+      rendered_path = rendered_path_for_namespace(namespace)
+      rendered_template = namespace.render_file(template_path)
+
+      FileUtils.mkdir_p rendered_path.dirname
+      File.write(rendered_path, rendered_template)
+    end
+
+    private
+
+    def rendered_path_for_namespace(namespace)
+      relative_path = template_path.relative_path_from(TEMPLATES_DIR_PATH)
+
+      # Content templates should be rendered once for each platform, to
+      # platform-specific directory, therefore if template path begins with
+      # 'content' directory this should be replaced with platform name in
+      # rendered path.
+      relative_rendered_path = relative_path
+        .sub(/^#{Constants::CONTENT_DIR_NAME}/, namespace.platform.to_s)
+        .sub(*namespace_identifier_sub_args(namespace))
+
+      Pathname.new(FilePath.rendered).join(relative_rendered_path)
+    end
+
+    def namespace_identifier_sub_args(namespace)
+      scope_type = namespace.scope_type
+      case scope_type
+      when :domain then ['', '']
+      when :group then ['group', "group/#{namespace.name}"]
+      when :node then ['node', "node/#{namespace.name}"]
+      else raise "Unhandled scope type: #{scope_type}"
+      end
+    end
+  end
+end

--- a/lib/underware/template.rb
+++ b/lib/underware/template.rb
@@ -26,9 +26,7 @@ module Underware
     def render_for(namespace)
       rendered_path = rendered_path_for_namespace(namespace)
       rendered_template = namespace.render_file(template_path)
-
-      FileUtils.mkdir_p rendered_path.dirname
-      File.write(rendered_path, rendered_template)
+      Utils.create_file(rendered_path, content: rendered_template)
     end
 
     private

--- a/lib/underware/template.rb
+++ b/lib/underware/template.rb
@@ -33,24 +33,27 @@ module Underware
 
     def rendered_path_for_namespace(namespace)
       relative_path = template_path.relative_path_from(TEMPLATES_DIR_PATH)
+      platform_part, scope_type_part, *rest = relative_path.to_s.split(File::SEPARATOR)
 
       # Content templates should be rendered once for each platform, to
-      # platform-specific directory, therefore if template path begins with
+      # platform-specific directory, therefore if platform part of path is
       # 'content' directory this should be replaced with platform name in
       # rendered path.
-      relative_rendered_path = relative_path
-        .sub(/^#{Constants::CONTENT_DIR_NAME}/, namespace.platform.to_s)
-        .sub(*namespace_identifier_sub_args(namespace))
+      if platform_part == Constants::CONTENT_DIR_NAME
+        platform_part = namespace.platform.to_s
+      end
 
-      Pathname.new(FilePath.rendered).join(relative_rendered_path)
+      namespace_name_dirs = any_namespace_name_dirs(namespace)
+      Pathname.new(FilePath.rendered).join(
+        platform_part, scope_type_part, *namespace_name_dirs, *rest
+      )
     end
 
-    def namespace_identifier_sub_args(namespace)
+    def any_namespace_name_dirs(namespace)
       scope_type = namespace.scope_type
       case scope_type
-      when :domain then ['', '']
-      when :group then ['group', "group/#{namespace.name}"]
-      when :node then ['node', "node/#{namespace.name}"]
+      when :domain then []
+      when :group, :node then [namespace.name]
       else raise "Unhandled scope type: #{scope_type}"
       end
     end

--- a/lib/underware/utils.rb
+++ b/lib/underware/utils.rb
@@ -32,6 +32,10 @@ module Underware
         end
       end
 
+      def class_name_parts(object)
+        object.class.to_s.downcase.split('::').map(&:to_sym)
+      end
+
       private
 
       # From

--- a/lib/underware/utils.rb
+++ b/lib/underware/utils.rb
@@ -36,6 +36,14 @@ module Underware
         object.class.to_s.downcase.split('::').map(&:to_sym)
       end
 
+      # Create file at any path, optionally with some content, by first
+      # creating every needed parent directory.
+      def create_file(path, content: '')
+        dir_path = File.dirname(path)
+        FileUtils.mkdir_p(dir_path)
+        File.write(path, content)
+      end
+
       private
 
       # From

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -50,42 +50,42 @@ RSpec.describe Underware::Commands::Template do
 
   it 'correctly renders all platform files for domain' do
     [
-      'platform_x/domain/template_1',
-      'platform_x/domain/template_2',
-      'platform_y/domain/template_1',
+      'platform_x/domain/some/path/template_1',
+      'platform_x/domain/some/path/template_2',
+      'platform_y/domain/some/path/template_1',
     ].each { |template| create_template(template) }
 
     run_command
 
     expect_rendered(
-      path: 'platform_x/domain/template_1',
+      path: 'platform_x/domain/some/path/template_1',
       for_platform: :platform_x,
       for_scope_type: :domain
     )
     expect_rendered(
-      path: 'platform_x/domain/template_2',
+      path: 'platform_x/domain/some/path/template_2',
       for_platform: :platform_x,
       for_scope_type: :domain
     )
     expect_rendered(
-      path: 'platform_y/domain/template_1',
+      path: 'platform_y/domain/some/path/template_1',
       for_platform: :platform_y,
       for_scope_type: :domain
     )
   end
 
   it 'correctly renders all content files for domain, for each platform' do
-    create_template 'content/domain/shared_template'
+    create_template 'content/domain/some/path/shared_template'
 
     run_command
 
     expect_rendered(
-      path: 'platform_x/domain/shared_template',
+      path: 'platform_x/domain/some/path/shared_template',
       for_platform: :platform_x,
       for_scope_type: :domain
     )
     expect_rendered(
-      path: 'platform_y/domain/shared_template',
+      path: 'platform_y/domain/some/path/shared_template',
       for_platform: :platform_y,
       for_scope_type: :domain
     )
@@ -93,31 +93,31 @@ RSpec.describe Underware::Commands::Template do
 
   it 'correctly renders all platform files for each group (including orphan group)' do
     Underware::GroupCache.update { |cache| cache.add(:user_configured_group) }
-    create_template 'platform_x/group/x_template'
-    create_template 'platform_y/group/y_template'
+    create_template 'platform_x/group/some/path/x_template'
+    create_template 'platform_y/group/some/path/y_template'
 
     run_command
 
     expect_rendered(
-      path: 'platform_x/group/user_configured_group/x_template',
+      path: 'platform_x/group/user_configured_group/some/path/x_template',
       for_platform: :platform_x,
       for_scope_type: :group,
       for_scope_name: 'user_configured_group'
     )
     expect_rendered(
-      path: 'platform_x/group/orphan/x_template',
+      path: 'platform_x/group/orphan/some/path/x_template',
       for_platform: :platform_x,
       for_scope_type: :group,
       for_scope_name: 'orphan'
     )
     expect_rendered(
-      path: 'platform_y/group/user_configured_group/y_template',
+      path: 'platform_y/group/user_configured_group/some/path/y_template',
       for_platform: :platform_y,
       for_scope_type: :group,
       for_scope_name: 'user_configured_group'
     )
     expect_rendered(
-      path: 'platform_y/group/orphan/y_template',
+      path: 'platform_y/group/orphan/some/path/y_template',
       for_platform: :platform_y,
       for_scope_type: :group,
       for_scope_name: 'orphan'
@@ -126,30 +126,30 @@ RSpec.describe Underware::Commands::Template do
 
   it 'correctly renders all content files for each group, for each platform' do
     Underware::GroupCache.update { |cache| cache.add(:user_configured_group) }
-    create_template 'content/group/shared_template'
+    create_template 'content/group/some/path/shared_template'
 
     run_command
 
     expect_rendered(
-      path: 'platform_x/group/user_configured_group/shared_template',
+      path: 'platform_x/group/user_configured_group/some/path/shared_template',
       for_platform: :platform_x,
       for_scope_type: :group,
       for_scope_name: 'user_configured_group'
     )
     expect_rendered(
-      path: 'platform_x/group/orphan/shared_template',
+      path: 'platform_x/group/orphan/some/path/shared_template',
       for_platform: :platform_x,
       for_scope_type: :group,
       for_scope_name: 'orphan'
     )
     expect_rendered(
-      path: 'platform_y/group/user_configured_group/shared_template',
+      path: 'platform_y/group/user_configured_group/some/path/shared_template',
       for_platform: :platform_y,
       for_scope_type: :group,
       for_scope_name: 'user_configured_group'
     )
     expect_rendered(
-      path: 'platform_y/group/orphan/shared_template',
+      path: 'platform_y/group/orphan/some/path/shared_template',
       for_platform: :platform_y,
       for_scope_type: :group,
       for_scope_name: 'orphan'
@@ -158,19 +158,19 @@ RSpec.describe Underware::Commands::Template do
 
   it 'correctly renders all platform files for each node' do
     allow(Underware::NodeattrInterface).to receive(:all_nodes).and_return(['some_node'])
-    create_template 'platform_x/node/x_template'
-    create_template 'platform_y/node/y_template'
+    create_template 'platform_x/node/some/path/x_template'
+    create_template 'platform_y/node/some/path/y_template'
 
     run_command
 
     expect_rendered(
-      path: 'platform_x/node/some_node/x_template',
+      path: 'platform_x/node/some_node/some/path/x_template',
       for_platform: :platform_x,
       for_scope_type: :node,
       for_scope_name: 'some_node'
     )
     expect_rendered(
-      path: 'platform_y/node/some_node/y_template',
+      path: 'platform_y/node/some_node/some/path/y_template',
       for_platform: :platform_y,
       for_scope_type: :node,
       for_scope_name: 'some_node'
@@ -179,18 +179,18 @@ RSpec.describe Underware::Commands::Template do
 
   it 'correctly renders all content files for each node, for each platform' do
     allow(Underware::NodeattrInterface).to receive(:all_nodes).and_return(['some_node'])
-    create_template 'content/node/shared_template'
+    create_template 'content/node/some/path/shared_template'
 
     run_command
 
     expect_rendered(
-      path: 'platform_x/node/some_node/shared_template',
+      path: 'platform_x/node/some_node/some/path/shared_template',
       for_platform: :platform_x,
       for_scope_type: :node,
       for_scope_name: 'some_node'
     )
     expect_rendered(
-      path: 'platform_y/node/some_node/shared_template',
+      path: 'platform_y/node/some_node/some/path/shared_template',
       for_platform: :platform_y,
       for_scope_type: :node,
       for_scope_name: 'some_node'

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -204,4 +204,32 @@ RSpec.describe Underware::Commands::Template do
 
     expect_not_rendered(path: 'unknown_platform/domain/some_template')
   end
+
+  it 'clears out pre-existing files from rendered files directory' do
+    previously_rendered_file_path = File.join(
+      Underware::Constants::RENDERED_PATH,
+      'some_platform/node/some_node/some_template'
+    )
+    FileUtils.mkdir_p(File.dirname(previously_rendered_file_path))
+    FileUtils.touch(previously_rendered_file_path)
+
+    run_command
+
+    expect(File.exists?(previously_rendered_file_path)).not_to be true
+  end
+
+  # Do not clear previously rendered system files to preserve rendered genders
+  # file, as well as any possible other future rendered system filess.
+  it 'does not clear out pre-existing files in rendered system files directory' do
+    previously_rendered_file_path = File.join(
+      Underware::Constants::RENDERED_PATH,
+      'system/some_file'
+    )
+    FileUtils.mkdir_p(File.dirname(previously_rendered_file_path))
+    FileUtils.touch(previously_rendered_file_path)
+
+    run_command
+
+    expect(File.exists?(previously_rendered_file_path)).to be true
+  end
 end

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe Underware::Commands::Template do
     expect_rendered(path: 'platform_y/domain/template_1', for_platform: :platform_y)
   end
 
+  it 'correctly renders all content files for domain, for each platform' do
+    create_template 'content/domain/shared_template'
+
+    run_command
+
+    expect_rendered(path: 'platform_x/domain/shared_template', for_platform: :platform_x)
+    expect_rendered(path: 'platform_y/domain/shared_template', for_platform: :platform_y)
+  end
+
   it 'does not render any files for platform without a config file' do
     create_template('unknown_platform/domain/some_template')
 

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Underware::Commands::Template do
 
     FileUtils.touch(Underware::FilePath.platform_config(:platform_x))
     FileUtils.touch(Underware::FilePath.platform_config(:platform_y))
+
+    # To render templates for nodes we need to be able to call this and have an
+    # array of nodes returned; stub this out so don't need to care about this
+    # when not explicitly testing rendering for nodes.
+    allow(Underware::NodeattrInterface).to receive(:all_nodes).and_return([])
   end
 
   it 'correctly renders all platform files for domain' do
@@ -148,6 +153,47 @@ RSpec.describe Underware::Commands::Template do
       for_platform: :platform_y,
       for_scope_type: :group,
       for_scope_name: 'orphan'
+    )
+  end
+
+  it 'correctly renders all platform files for each node' do
+    allow(Underware::NodeattrInterface).to receive(:all_nodes).and_return(['some_node'])
+    create_template 'platform_x/node/x_template'
+    create_template 'platform_y/node/y_template'
+
+    run_command
+
+    expect_rendered(
+      path: 'platform_x/node/some_node/x_template',
+      for_platform: :platform_x,
+      for_scope_type: :node,
+      for_scope_name: 'some_node'
+    )
+    expect_rendered(
+      path: 'platform_y/node/some_node/y_template',
+      for_platform: :platform_y,
+      for_scope_type: :node,
+      for_scope_name: 'some_node'
+    )
+  end
+
+  it 'correctly renders all content files for each node, for each platform' do
+    allow(Underware::NodeattrInterface).to receive(:all_nodes).and_return(['some_node'])
+    create_template 'content/node/shared_template'
+
+    run_command
+
+    expect_rendered(
+      path: 'platform_x/node/some_node/shared_template',
+      for_platform: :platform_x,
+      for_scope_type: :node,
+      for_scope_name: 'some_node'
+    )
+    expect_rendered(
+      path: 'platform_y/node/some_node/shared_template',
+      for_platform: :platform_y,
+      for_scope_type: :node,
+      for_scope_name: 'some_node'
     )
   end
 

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Underware::Commands::Template do
 
   def create_template(relative_path)
     path = File.join(Underware::FilePath.templates_dir, relative_path)
-    FileUtils.mkdir_p(File.dirname(path))
 
     # Create minimal template which just includes things we want to assert
     # presence of in `expect_rendered`.
@@ -15,7 +14,8 @@ RSpec.describe Underware::Commands::Template do
       scope_type: <%= alces.scope.scope_type %>
       scope_name: <%= alces.scope.name if alces.scope.respond_to?(:name) %>
     TEMPLATE
-    File.write(path, template)
+
+    Underware::Utils.create_file(path, content: template)
   end
 
   def expect_rendered(path:, for_platform:, for_scope_type:, for_scope_name: nil)
@@ -210,8 +210,7 @@ RSpec.describe Underware::Commands::Template do
       Underware::Constants::RENDERED_PATH,
       'some_platform/node/some_node/some_template'
     )
-    FileUtils.mkdir_p(File.dirname(previously_rendered_file_path))
-    FileUtils.touch(previously_rendered_file_path)
+    Underware::Utils.create_file(previously_rendered_file_path)
 
     run_command
 
@@ -225,8 +224,7 @@ RSpec.describe Underware::Commands::Template do
       Underware::Constants::RENDERED_PATH,
       'system/some_file'
     )
-    FileUtils.mkdir_p(File.dirname(previously_rendered_file_path))
-    FileUtils.touch(previously_rendered_file_path)
+    Underware::Utils.create_file(previously_rendered_file_path)
 
     run_command
 

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe Underware::Commands::Template do
     expect_rendered(path: 'platform_y/domain/shared_template', for_platform: :platform_y)
   end
 
+  it 'correctly renders all platform files for each group (including orphan group)' do
+    Underware::GroupCache.update { |cache| cache.add(:user_configured_group) }
+    create_template 'platform_x/group/x_template'
+    create_template 'platform_y/group/y_template'
+
+    run_command
+
+    expect_rendered(path: 'platform_x/group/user_configured_group/x_template', for_platform: :platform_x)
+    expect_rendered(path: 'platform_x/group/orphan/x_template', for_platform: :platform_x)
+    expect_rendered(path: 'platform_y/group/user_configured_group/y_template', for_platform: :platform_y)
+    expect_rendered(path: 'platform_y/group/orphan/y_template', for_platform: :platform_y)
+  end
+
   it 'does not render any files for platform without a config file' do
     create_template('unknown_platform/domain/some_template')
 

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -1,0 +1,41 @@
+
+RSpec.describe Underware::Commands::Template do
+  def run_command
+    Underware::Utils.run_command(described_class)
+  end
+
+  def create_template(relative_path)
+    path = File.join(Underware::FilePath.templates_dir, relative_path)
+    FileUtils.mkdir_p(File.dirname(path))
+
+    # Create minimal template which just includes the platform it was rendered
+    # for.
+    File.write(path, "platform: <%= alces.platform %>")
+  end
+
+  def expect_rendered(path:, for_platform:)
+    expect(
+      File.read("#{Underware::Constants::RENDERED_PATH}/#{path}")
+    ).to include("platform: #{for_platform}")
+  end
+
+  before :each do
+    # Ensure templates directory is initially empty, so only testing with files
+    # setup in individual tests.
+    FileUtils.rm_rf(Underware::FilePath.templates_dir)
+  end
+
+  it 'correctly renders all platform files for domain' do
+    [
+      'platform_x/domain/template_1',
+      'platform_x/domain/template_2',
+      'platform_y/domain/template_1',
+    ].each { |template| create_template(template) }
+
+    run_command
+
+    expect_rendered(path: 'platform_x/domain/template_1', for_platform: :platform_x)
+    expect_rendered(path: 'platform_x/domain/template_2', for_platform: :platform_x)
+    expect_rendered(path: 'platform_y/domain/template_1', for_platform: :platform_y)
+  end
+end

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -230,4 +230,19 @@ RSpec.describe Underware::Commands::Template do
 
     expect(File.exists?(previously_rendered_file_path)).to be true
   end
+
+  it 'is not over-eager when replacing in rendered paths' do
+    FileUtils.touch(Underware::FilePath.platform_config(:node_platform))
+    allow(Underware::NodeattrInterface).to receive(:all_nodes).and_return(['some_node'])
+    create_template 'node_platform/node/my_favourite_node_templates/node/template'
+
+    run_command
+
+    expect_rendered(
+      path: 'node_platform/node/some_node/my_favourite_node_templates/node/template',
+      for_platform: :node_platform,
+      for_scope_type: :node,
+      for_scope_name: 'some_node'
+    )
+  end
 end

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -19,10 +19,19 @@ RSpec.describe Underware::Commands::Template do
     ).to include("platform: #{for_platform}")
   end
 
+  def expect_not_rendered(path:)
+    expect(
+      File.exists?("#{Underware::Constants::RENDERED_PATH}/#{path}")
+    ).to be false
+  end
+
   before :each do
     # Ensure templates directory is initially empty, so only testing with files
     # setup in individual tests.
     FileUtils.rm_rf(Underware::FilePath.templates_dir)
+
+    FileUtils.touch(Underware::FilePath.platform_config(:platform_x))
+    FileUtils.touch(Underware::FilePath.platform_config(:platform_y))
   end
 
   it 'correctly renders all platform files for domain' do
@@ -37,5 +46,13 @@ RSpec.describe Underware::Commands::Template do
     expect_rendered(path: 'platform_x/domain/template_1', for_platform: :platform_x)
     expect_rendered(path: 'platform_x/domain/template_2', for_platform: :platform_x)
     expect_rendered(path: 'platform_y/domain/template_1', for_platform: :platform_y)
+  end
+
+  it 'does not render any files for platform without a config file' do
+    create_template('unknown_platform/domain/some_template')
+
+    run_command
+
+    expect_not_rendered(path: 'unknown_platform/domain/some_template')
   end
 end

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Underware::Commands::Template do
     # presence of in `expect_rendered`.
     template = <<~TEMPLATE
       platform: <%= alces.platform %>
-      scope_type: <%= alces.scope.class.to_s.downcase.split('::').last %>
+      scope_type: <%= alces.scope.scope_type %>
       scope_name: <%= alces.scope.name if alces.scope.respond_to?(:name) %>
     TEMPLATE
     File.write(path, template)

--- a/spec/commands/template_spec.rb
+++ b/spec/commands/template_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe Underware::Commands::Template do
     expect_rendered(path: 'platform_y/group/orphan/y_template', for_platform: :platform_y)
   end
 
+  it 'correctly renders all content files for each group, for each platform' do
+    Underware::GroupCache.update { |cache| cache.add(:user_configured_group) }
+    create_template 'content/group/shared_template'
+
+    run_command
+
+    expect_rendered(path: 'platform_x/group/user_configured_group/shared_template', for_platform: :platform_x)
+    expect_rendered(path: 'platform_x/group/orphan/shared_template', for_platform: :platform_x)
+    expect_rendered(path: 'platform_y/group/user_configured_group/shared_template', for_platform: :platform_y)
+    expect_rendered(path: 'platform_y/group/orphan/shared_template', for_platform: :platform_y)
+  end
+
   it 'does not render any files for platform without a config file' do
     create_template('unknown_platform/domain/some_template')
 

--- a/spec/filesystem.rb
+++ b/spec/filesystem.rb
@@ -51,14 +51,6 @@ class FileSystem
       Underware::Plugins.activate!(plugin_name)
     end
 
-    # Create an empty file given any path, by creating every needed parent
-    # directory and then the file itself.
-    def create(file_path)
-      dir_path = File.dirname(file_path)
-      FileUtils.mkdir_p(dir_path)
-      FileUtils.touch(file_path)
-    end
-
     # Perform arbitrary other FileSystem setup.
     # TODO Maybe everything/more things should be changed to just do this,
     # rather than continuing to add new methods here every time we want to

--- a/spec/shared_examples/hash_merger_namespace.rb
+++ b/spec/shared_examples/hash_merger_namespace.rb
@@ -31,4 +31,21 @@ RSpec.shared_examples \
       expect(subject.to_h[:answer]).to eq(test_answer)
     end
   end
+
+  describe '#scope_type' do
+    it 'gives correct scope type' do
+      expected_scope_type = case subject
+                            when Underware::Namespaces::Domain
+                              :domain
+                            when Underware::Namespaces::Group
+                              :group
+                            when Underware::Namespaces::Node
+                              :node
+                            else
+                              raise "Unhandled class: #{subject.class}"
+                            end
+
+      expect(subject.scope_type).to eq(expected_scope_type)
+    end
+  end
 end

--- a/spec/shared_examples/record.rb
+++ b/spec/shared_examples/record.rb
@@ -29,8 +29,7 @@ RSpec.shared_examples 'record' do |file_path_proc|
       paths << File.expand_path(file_path_proc.call('.', legacy))
     end
     paths.each do |path|
-      FileUtils.mkdir_p(File.dirname(path))
-      FileUtils.touch(path)
+      Underware::Utils.create_file(path)
     end
   end
 


### PR DESCRIPTION
This PR adds the initial implementation of the `template` command, and so closes https://github.com/alces-software/underware/issues/19. The best explanation for what this command does can be seen in the plan for how it should work in that issue, or more briefly via `underware template -h`:
```
[root@localhost underware]# underware template -h

  NAME:

    template

  SYNOPSIS:

    underware template [options]

  DESCRIPTION:

    This command renders all the templates provided by Underware for every combination of platform and scope that
this installation of Underware is configured with.

    Specifically this consists of rendering, for every platform, the available domain, group, and node templates
(both platform-specific and platform-independent content), for the domain, every group, and every node
respectively.

    The rendered templates can then be used, on their own or in combination with other Alces tools, to deploy,
configure, or otherwise manage, a cluster at different scales and across different platforms.
```

Basically, it does this:

<details>

```
[root@localhost underware]# underware configure domain
[...snip...]

[root@localhost underware]# underware configure group bobnodes
List of hosts for the group (in genders format, e.g. "node01,node[05-08]") (1/5)
bobnode[01-10]
[...snip...]

[root@localhost underware]# underware configure group stunodes
List of hosts for the group (in genders format, e.g. "node01,node[05-08]") (1/5)
stunode[01-05]
[...snip...]

[root@localhost underware]# tree /var/lib/underware/rendered/
/var/lib/underware/rendered/
└── system
    └── genders

1 directory, 1 file
[root@localhost underware]# underware template
[root@localhost underware]# tree /var/lib/underware/rendered/
/var/lib/underware/rendered/
├── aws
│   ├── domain
│   │   ├── domainandallnodes.yaml
│   │   └── domain.yaml
│   ├── group
│   │   ├── bobnodes
│   │   │   └── group.yaml
│   │   ├── orphan
│   │   │   └── group.yaml
│   │   └── stunodes
│   │       └── group.yaml
│   └── node
│       ├── bobnode01
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode02
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode03
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode04
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode05
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode06
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode07
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode08
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode09
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── bobnode10
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── stunode01
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── stunode02
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── stunode03
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       ├── stunode04
│       │   ├── base
│       │   │   └── main.sh
│       │   ├── cloudimage
│       │   │   └── main.sh
│       │   ├── main.sh
│       │   ├── networking
│       │   │   ├── hosts.sh
│       │   │   ├── main.sh
│       │   │   └── networking.sh
│       │   └── node.yaml
│       └── stunode05
│           ├── base
│           │   └── main.sh
│           ├── cloudimage
│           │   └── main.sh
│           ├── main.sh
│           ├── networking
│           │   ├── hosts.sh
│           │   ├── main.sh
│           │   └── networking.sh
│           └── node.yaml
├── azure
│   ├── domain
│   │   ├── domainandallnodes.json
│   │   └── domain.json
│   ├── group
│   │   ├── bobnodes
│   │   │   └── group.json
│   │   ├── orphan
│   │   │   └── group.json
│   │   └── stunodes
│   │       └── group.json
│   └── node

[...snip, this goes on for ages...]

261 directories, 431 files
```

</details>