### PR TITLE
Add interface question type

### DIFF
--- a/data/configure.yaml
+++ b/data/configure.yaml
@@ -17,6 +17,7 @@ questions:
   - &configured_build_interface
     identifier: configured_build_interface
     question: 'Interface of this machine that the cluster should be built on (will determine IP of this machine to use when templating)'
+    type: interface
 
   #
   # GROUPS

--- a/lib/underware/configurator/question.rb
+++ b/lib/underware/configurator/question.rb
@@ -88,6 +88,34 @@ module Underware
         highline.ask(question_text) { |q| yield q }
       end
 
+      def ask_interface_question
+        if available_network_interfaces.length == 1
+          default_to_first_interface
+        else
+          choose_between_available_interfaces { |q| yield q }
+        end
+      end
+
+      def available_network_interfaces
+        @available_network_interfaces ||= Network.available_interfaces
+      end
+
+      def default_to_first_interface
+        available_network_interfaces.first.tap do |first_interface|
+          $stderr.puts <<~MESSAGE.strip_heredoc
+            #{question_text}
+            [Only one interface available, defaulting to '#{first_interface}']
+          MESSAGE
+        end
+      end
+
+      def choose_between_available_interfaces
+        highline.choose(*available_network_interfaces) do |menu|
+          menu.prompt = question_text
+          yield menu
+        end
+      end
+
       def question_text
         "#{text.strip} #{progress_indicator}"
       end

--- a/lib/underware/configurator/question.rb
+++ b/lib/underware/configurator/question.rb
@@ -74,7 +74,11 @@ module Underware
       end
 
       def ask_choice_question
-        highline.choose(*choices) do |menu|
+        offer_choice_between(choices) { |q| yield q }
+      end
+
+      def offer_choice_between(possible_choices)
+        highline.choose(*possible_choices) do |menu|
           menu.prompt = question_text
           yield menu
         end
@@ -92,7 +96,7 @@ module Underware
         if available_network_interfaces.length == 1
           default_to_first_interface
         else
-          choose_between_available_interfaces { |q| yield q }
+          offer_choice_between(available_network_interfaces) { |q| yield q }
         end
       end
 
@@ -106,13 +110,6 @@ module Underware
             #{question_text}
             [Only one interface available, defaulting to '#{first_interface}']
           MESSAGE
-        end
-      end
-
-      def choose_between_available_interfaces
-        highline.choose(*available_network_interfaces) do |menu|
-          menu.prompt = question_text
-          yield menu
         end
       end
 

--- a/lib/underware/exceptions.rb
+++ b/lib/underware/exceptions.rb
@@ -42,6 +42,7 @@ module Underware
   class DataError < UserUnderwareError; end
   class UninitializedLocalNode < UserUnderwareError; end
   class MissingRecordError < UserUnderwareError; end
+  class NoNetworkInterfacesAvailable < UserUnderwareError; end
 
   class RecursiveConfigDepthExceededError < UserUnderwareError
     def initialize(msg = 'Input hash may contain infinitely recursive ERB')

--- a/lib/underware/namespaces/alces.rb
+++ b/lib/underware/namespaces/alces.rb
@@ -224,7 +224,7 @@ module Underware
         else
           # Default to first network interface if `build_interface` has not
           # been configured by user.
-          Network.interfaces.first
+          Network.available_interfaces.first
         end
       end
     end

--- a/lib/underware/network.rb
+++ b/lib/underware/network.rb
@@ -15,7 +15,12 @@ module Underware
       # delegate :interfaces, to: NetworkInterface, private: true
 
       def available_interfaces
-        (interfaces - [LOOPBACK]).sort
+        (interfaces - [LOOPBACK]).sort.tap do |available|
+          if available.empty?
+            raise NoNetworkInterfacesAvailable,
+              'No network interfaces available, unable to proceed'
+          end
+        end
       end
     end
   end

--- a/lib/underware/network.rb
+++ b/lib/underware/network.rb
@@ -6,7 +6,17 @@ require 'network_interface'
 module Underware
   module Network
     class << self
-      delegate :interfaces, to: NetworkInterface
+      LOOPBACK = 'lo'
+
+      # Upgrade `activesupport` and swap these, once a version containing
+      # https://github.com/rails/rails/pull/31944 has been released (not in a
+      # released version of `activesupport` yet, as of 5.2.2):
+      private *delegate(:interfaces, to: NetworkInterface)
+      # delegate :interfaces, to: NetworkInterface, private: true
+
+      def available_interfaces
+        (interfaces - [LOOPBACK]).sort
+      end
     end
   end
 end

--- a/lib/underware/validation/answer.rb
+++ b/lib/underware/validation/answer.rb
@@ -143,16 +143,7 @@ module Underware
           config.namespace = 'answer'
 
           def answer_type?(value)
-            case value[:type]
-            when nil || 'string'
-              value[:answer].is_a? String
-            when 'integer'
-              value[:answer].is_a? Integer
-            when 'boolean'
-              [true, false].include?(value[:answer])
-            else
-              false
-            end
+            Configure.type_check(value[:type], value[:answer])
           end
         end
 

--- a/lib/underware/validation/configure.rb
+++ b/lib/underware/validation/configure.rb
@@ -35,7 +35,6 @@ require 'underware/validation/configure/schemas'
 module Underware
   module Validation
     class Configure
-      # NOTE: Supported types in error.yaml message must be updated manually
       SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'interface'].freeze
 
       def self.type_check(type, value)

--- a/lib/underware/validation/configure.rb
+++ b/lib/underware/validation/configure.rb
@@ -36,7 +36,7 @@ module Underware
   module Validation
     class Configure
       # NOTE: Supported types in error.yaml message must be updated manually
-      SUPPORTED_TYPES = ['string', 'integer', 'boolean'].freeze
+      SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'interface'].freeze
 
       def self.type_check(type, value)
         case type
@@ -46,6 +46,8 @@ module Underware
           value.is_a?(Integer)
         when 'boolean'
           [true, false].include?(value)
+        when 'interface'
+          Network.available_interfaces.include?(value)
         else
           false
         end

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Underware::Configurator do
       expect(answers).to eq(boolean_q: true)
     end
 
-    it "offers choices for question with type 'choice'" do
+    it "offers choices for question with 'choices' key set" do
       define_questions(domain: [
                          {
                            identifier: 'choice_q',

--- a/spec/configurator_spec.rb
+++ b/spec/configurator_spec.rb
@@ -189,6 +189,51 @@ RSpec.describe Underware::Configurator do
       expect(answers).to eq(choice_q: 'bar')
     end
 
+    context "for question with type 'interface'" do
+      before :each do
+        define_questions(domain: [
+          {
+            identifier: 'interface_q',
+            type: 'interface',
+            question: 'What interface should we use?',
+          },
+        ])
+      end
+
+      it 'offers choice from available interfaces when multiple interfaces available' do
+        allow(Underware::Network)
+          .to receive(:available_interfaces)
+          .and_return(['eth0', 'eth1'])
+
+        expect(highline).to receive(
+          :choose
+        ).with(
+          'eth0', 'eth1'
+        ).and_call_original
+
+        configure_with_answers(['eth1'])
+
+        expect(answers).to eq(interface_q: 'eth1')
+      end
+
+      it 'automatically uses only interface when single interface available' do
+        allow(Underware::Network)
+          .to receive(:available_interfaces)
+          .and_return(['eth0'])
+
+        stderr = Underware::AlcesUtils.redirect_std(:stderr) do
+          configure_with_answers([])
+        end[:stderr].read
+
+        expect(answers).to eq(interface_q: 'eth0')
+        expected_message = <<~INFO.strip_heredoc
+          What interface should we use? (1/1)
+          [Only one interface available, defaulting to 'eth0']
+        INFO
+        expect(stderr).to include(expected_message)
+      end
+    end
+
     it 'asks all questions in order' do
       define_questions(domain: [
                          {

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Underware::Namespaces::Alces do
 
     it 'gives first available network interface if answer not present' do
       allow(Underware::Network)
-        .to receive(:interfaces)
+        .to receive(:available_interfaces)
         .and_return(['eth2', 'eth4'])
       # Guarantee no answers present.
       Underware::Data.dump(Underware::FilePath.domain_answers, {})

--- a/spec/namespaces/alces_spec.rb
+++ b/spec/namespaces/alces_spec.rb
@@ -153,19 +153,22 @@ RSpec.describe Underware::Namespaces::Alces do
   end
 
   describe '#build_interface' do
-    it 'gives answer to configured_build_interface question if present' do
-      Underware::Data.dump(
-        Underware::FilePath.domain_answers,
-        configured_build_interface: 'eth3'
-      )
-
-      expect(alces.build_interface).to eq('eth3')
-    end
-
-    it 'gives first available network interface if answer not present' do
+    before :each do
       allow(Underware::Network)
         .to receive(:available_interfaces)
         .and_return(['eth2', 'eth4'])
+    end
+
+    it 'gives answer to configured_build_interface question if present' do
+      Underware::Data.dump(
+        Underware::FilePath.domain_answers,
+        configured_build_interface: 'eth4'
+      )
+
+      expect(alces.build_interface).to eq('eth4')
+    end
+
+    it 'gives first available network interface if answer not present' do
       # Guarantee no answers present.
       Underware::Data.dump(Underware::FilePath.domain_answers, {})
 

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -10,5 +10,13 @@ RSpec.describe Underware::Network do
         described_class.available_interfaces
       ).to eq(['eth0', 'eth1', 'eth2'])
     end
+
+    it 'raises if no interfaces that we want to consider available' do
+      allow(NetworkInterface).to receive(:interfaces).and_return(['lo'])
+
+      expect{
+        described_class.available_interfaces
+      }.to raise_error(Underware::NoNetworkInterfacesAvailable)
+    end
   end
 end

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -1,0 +1,14 @@
+
+RSpec.describe Underware::Network do
+  describe '#available_interfaces' do
+    it 'returns all interface names, minus loopback, sorted' do
+      allow(NetworkInterface).to receive(:interfaces).and_return([
+        'eth1', 'eth0', 'lo', 'eth2'
+      ])
+
+      expect(
+        described_class.available_interfaces
+      ).to eq(['eth0', 'eth1', 'eth2'])
+    end
+  end
+end


### PR DESCRIPTION
This PR implements a new type of configure question, the `interface` type, which allows choosing between the available network interfaces of the machine Underware is running on. This question is then used for the `configured_build_interface` question in our current `configure.yaml`. This resolves https://github.com/alces-software/underware/issues/25.