### PR TITLE
Add password question type; use for `root_password` question

### DIFF
--- a/data/configure.yaml
+++ b/data/configure.yaml
@@ -8,7 +8,8 @@ questions:
 
   - &root_password
     identifier: root_password
-    question: 'Password to use for root user (generate with `openssl passwd -1`)'
+    question: 'Password to use for root user'
+    type: password
 
   - &configured_build_interface
     identifier: configured_build_interface

--- a/lib/underware/configurator/question.rb
+++ b/lib/underware/configurator/question.rb
@@ -58,8 +58,6 @@ module Underware
       end
 
       def default_input
-        return human_readable_boolean_default if type.boolean?
-
         # For password questions we don't want to set a default on the HighLine
         # question itself as:
         # a. it will be an encrypted password from previous `configure`, and so
@@ -67,9 +65,11 @@ module Underware
         # b. `ask_password_question` handles changing or retaining a previous
         # password itself as needed, without the re-encryption which would
         # occur if we set the default to a previously encrypted password here.
-        return if type.password?
-
-        default.nil? ? default : default.to_s
+        case type.to_sym
+        when :boolean then human_readable_boolean_default
+        when :password then nil
+        else default&.to_s
+        end
       end
 
       # Default for a boolean question which has a previous answer should be

--- a/lib/underware/configurator/question.rb
+++ b/lib/underware/configurator/question.rb
@@ -113,6 +113,36 @@ module Underware
         end
       end
 
+      def ask_password_question
+        encrypt_password(request_password_with_confirmation)
+      end
+
+      def request_password_with_confirmation
+        loop do
+          password = ask_for_password(question_text)
+          confirmation = ask_for_password('Confirm password:')
+
+          return password if password == confirmation
+          $stderr.puts 'Password and confirmation do not match - please try again.'
+        end
+      end
+
+      def ask_for_password(prompt_text)
+        highline.ask(prompt_text) do |q|
+          configure_question(q)
+          q.echo = '*'
+        end
+      end
+
+      def encrypt_password(plaintext_password)
+        # Encrypt password with salt, in format expected by `/etc/shadow` (`$6`
+        # => use SHA-512). Relevant links:
+        # https://www.cyberciti.biz/faq/understanding-etcshadow-file/ and
+        # https://stackoverflow.com/a/5174746/2620402.
+        salt = SecureRandom.base64
+        plaintext_password.crypt("$6$#{salt}")
+      end
+
       def question_text
         "#{text.strip} #{progress_indicator}"
       end

--- a/lib/underware/validation/configure.rb
+++ b/lib/underware/validation/configure.rb
@@ -35,7 +35,12 @@ require 'underware/validation/configure/schemas'
 module Underware
   module Validation
     class Configure
-      SUPPORTED_TYPES = ['string', 'integer', 'boolean', 'interface'].freeze
+      SUPPORTED_TYPES = [
+        'boolean',
+        'integer',
+        'interface',
+        'string',
+      ].freeze
 
       def self.type_check(type, value)
         case type

--- a/lib/underware/validation/configure.rb
+++ b/lib/underware/validation/configure.rb
@@ -39,12 +39,13 @@ module Underware
         'boolean',
         'integer',
         'interface',
+        'password',
         'string',
       ].freeze
 
       def self.type_check(type, value)
         case type
-        when 'string', nil
+        when 'string', 'password', nil
           value.is_a?(String)
         when 'integer'
           value.is_a?(Integer)

--- a/spec/underware/configurator_spec.rb
+++ b/spec/underware/configurator_spec.rb
@@ -72,26 +72,14 @@ RSpec.describe Underware::Configurator do
     allow(Underware::Validation::Configure).to receive(:new).and_return(v)
   end
 
-  def redirect_stdout
-    $stdout = tmp = Tempfile.new
-    yield
-    tmp.close
-  rescue StandardError => e
-    $stdout.rewind
-    STDERR.puts $stdout.read
-    raise e
-  ensure
-    $stdout = STDOUT
-  end
-
   def configure_with_input(input_string, test_obj: configurator)
-    redirect_stdout do
+    Underware::AlcesUtils.redirect_std(:stdout) do
       input.read # Move to the end of the file
       count = input.write(input_string)
       input.pos = (input.pos - count) # Move to the start of new content
       test_obj.configure
       reset_alces
-    end
+    end[:stdout].read
   end
 
   def configure_with_answers(answers, test_obj: configurator)
@@ -412,8 +400,7 @@ RSpec.describe Underware::Configurator do
         should_keep_old_answer: 'old answer',
       }
 
-      first_run_configure = nil
-      redirect_stdout do
+      Underware::AlcesUtils.redirect_std(:stdout) do
         first_run_configure = make_configurator
         first_run_configure.send(:save_answers, original_answers)
       end

--- a/spec/underware/configurator_spec.rb
+++ b/spec/underware/configurator_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Underware::Configurator do
     allow(Underware::Validation::Configure).to receive(:new).and_return(v)
   end
 
+  def configure_with_answers(answers, test_obj: configurator)
+    # Each answer must be entered followed by a newline to terminate it.
+    configure_with_input(answers.join("\n") + "\n", test_obj: test_obj)
+  end
+
   def configure_with_input(input_string, test_obj: configurator)
     Underware::AlcesUtils.redirect_std(:stdout) do
       input.read # Move to the end of the file
@@ -80,11 +85,6 @@ RSpec.describe Underware::Configurator do
       test_obj.configure
       reset_alces
     end[:stdout].read
-  end
-
-  def configure_with_answers(answers, test_obj: configurator)
-    # Each answer must be entered followed by a newline to terminate it.
-    configure_with_input(answers.join("\n") + "\n", test_obj: test_obj)
   end
 
   # Do not want to use readline to get input in tests as tests will then


### PR DESCRIPTION
This PR adds a new `password` question type, and this new question type is then used for the `root_password` question in the Underware content; this therefore resolves #18.

The implementation is as described in that issue; note that the entered password will be saved in encrypted form, using SHA-512 with a random salt, in the format expected by the `/etc/shadow` file.

Also included are a few other tweaks to the configuration process/tests, where I noticed some simple improvements which could be made.