### PR TITLE
Create a command to streamline the first create process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.4.0)
+    byebug (10.0.2)
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.4)
@@ -85,6 +86,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rainbow (3.0.0)
     recursive-open-struct (1.1.0)
     rspec (3.8.0)
@@ -126,10 +130,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.0)
   commander!
   fakefs
   pry
+  pry-byebug
   rspec
   rubocop (~> 0.52.1)
   rubocop-rspec
@@ -141,4 +146,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.6
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler
   commander!
   fakefs
   pry
@@ -146,4 +146,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   2.0.1
+   1.16.0

--- a/data/config/gateway1.yaml
+++ b/data/config/gateway1.yaml
@@ -1,0 +1,3 @@
+networks:
+  network1:
+    gateway: 10.10.0.1

--- a/data/init/groups/login.yaml
+++ b/data/init/groups/login.yaml
@@ -1,0 +1,3 @@
+---
+hostname_range: gateway1
+role: login

--- a/data/init/groups/nodes.yaml
+++ b/data/init/groups/nodes.yaml
@@ -1,0 +1,3 @@
+---
+hostname_range: node[01-10]
+role: compute

--- a/data/init/nodes/gateway.yaml
+++ b/data/init/nodes/gateway.yaml
@@ -1,0 +1,2 @@
+---
+is_gateway: true

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -230,6 +230,11 @@ commands:
     options:
       - *gender_option
 
+  init: &init
+    syntax: underware init [options]
+    summary: Create a basic cluster configuration
+    action: Commands::Init
+
   layout:
     syntax: underware layout [SUB_COMMAND] [options]
     summary: Manage the layout record files

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -40,14 +40,18 @@ module Underware
 
       def start(args, options)
         global_setup(options)
-        pre_setup(args, options)
-        setup
-        post_setup
-        run
+        run!(args, options)
       rescue Interrupt => e
         handle_interrupt(e)
       rescue IntentionallyCatchAnyException => e
         handle_fatal_exception(e)
+      end
+
+      def run!(args, options)
+        pre_setup(args, options)
+        setup
+        post_setup
+        run
       end
 
       private

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -39,6 +39,7 @@ module Underware
       end
 
       def start(args, options)
+        global_setup(options)
         pre_setup(args, options)
         setup
         post_setup
@@ -53,9 +54,12 @@ module Underware
 
       attr_reader :args, :options
 
-      def pre_setup(args, options)
+      def global_setup(options)
         setup_global_log_options(options)
         log_command
+      end
+
+      def pre_setup(args, options)
         @args = args
         @options = options
       end

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -120,6 +120,10 @@ module Underware
         )
       end
 
+      def reset_alces
+        @alces = nil
+      end
+
       def platform_option
         platform = options.platform
         return unless platform

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -33,9 +33,15 @@ require 'underware/namespaces/alces'
 module Underware
   module CommandHelpers
     class BaseCommand
+      def self.options
+        Commander::Command::Options.new
+      end
+
       def initialize(args = [], options = nil, noop: false)
-        options ||= Commander::Command::Options.new
-        start(args, options) unless noop
+        unless noop
+          options ||= self.class.options
+          start(args, options)
+        end
       end
 
       def start(args, options)

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -37,7 +37,8 @@ module Underware
         Commander::Command::Options.new
       end
 
-      def initialize(args = [], options = nil, noop: false)
+      def initialize(args = [], options = nil, noop: false, alces: nil)
+        @alces ||= alces
         unless noop
           options ||= self.class.options
           start(args, options)

--- a/lib/underware/command_helpers/base_command.rb
+++ b/lib/underware/command_helpers/base_command.rb
@@ -33,7 +33,12 @@ require 'underware/namespaces/alces'
 module Underware
   module CommandHelpers
     class BaseCommand
-      def initialize(args, options)
+      def initialize(args = [], options = nil, noop: false)
+        options ||= Commander::Command::Options.new
+        start(args, options) unless noop
+      end
+
+      def start(args, options)
         pre_setup(args, options)
         setup
         post_setup

--- a/lib/underware/command_helpers/configure_command.rb
+++ b/lib/underware/command_helpers/configure_command.rb
@@ -41,6 +41,7 @@ module Underware
         full_new_genders_content = ManagedFile.content(
           FilePath.genders, rendered_genders_content
         )
+        FileUtils.mkdir_p(File.dirname(FilePath.genders))
         File.write(FilePath.genders, full_new_genders_content)
       end
 

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#==============================================================================
+#
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Underware.
+#
+# Alces Underware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Underware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Underware, please visit:
+# https://github.com/alces-software/underware
+#==============================================================================
+
+module Underware
+  module Commands
+    class Init < CommandHelpers::BaseCommand
+      private
+
+      def setup; end
+
+      def run; end
+    end
+  end
+end

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -38,6 +38,7 @@ module Underware
         # Run the domain configuration
         configure_domain
         configure_login_group
+        configure_login_nodes
       end
 
       private
@@ -50,6 +51,15 @@ module Underware
         new_command(Configure::Group).run!(
           [LOGIN_GROUP], load_answer_options("groups/#{LOGIN_GROUP}.yaml")
         )
+      end
+
+      def configure_login_nodes
+        reset_alces
+        alces.groups.login.nodes.each do |node|
+          new_command(Configure::Node).run!(
+            [node.name], load_answer_options("nodes/gateway.yaml")
+          )
+        end
       end
 
       def new_command(klass)

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -38,8 +38,8 @@ module Underware
       def run
         # Run the domain configuration
         configure_domain
-        configure_login_group
-        configure_nodes_group
+        configure_group(LOGIN_GROUP)
+        configure_group(NODES_GROUP)
         configure_login_nodes
         template
       end
@@ -50,15 +50,9 @@ module Underware
         new_command(Configure::Domain).run!([], self.class.options)
       end
 
-      def configure_login_group
+      def configure_group(name)
         new_command(Configure::Group).run!(
-          [LOGIN_GROUP], load_answers_options("groups/#{LOGIN_GROUP}.yaml")
-        )
-      end
-
-      def configure_nodes_group
-        new_command(Configure::Group).run!(
-          [NODES_GROUP], load_answers_options("groups/#{NODES_GROUP}.yaml")
+          [name], load_answers_options("groups/#{name}.yaml")
         )
       end
 

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -52,13 +52,13 @@ module Underware
 
       def configure_login_group
         new_command(Configure::Group).run!(
-          [LOGIN_GROUP], load_answer_options("groups/#{LOGIN_GROUP}.yaml")
+          [LOGIN_GROUP], load_answers_options("groups/#{LOGIN_GROUP}.yaml")
         )
       end
 
       def configure_nodes_group
         new_command(Configure::Group).run!(
-          [NODES_GROUP], load_answer_options("groups/#{NODES_GROUP}.yaml")
+          [NODES_GROUP], load_answers_options("groups/#{NODES_GROUP}.yaml")
         )
       end
 
@@ -66,7 +66,7 @@ module Underware
         reset_alces
         alces.groups.login.nodes.each do |node|
           new_command(Configure::Node).run!(
-            [node.name], load_answer_options("nodes/gateway.yaml")
+            [node.name], load_answers_options("nodes/gateway.yaml")
           )
         end
       end
@@ -80,7 +80,7 @@ module Underware
         klass.new(noop: true, alces: alces)
       end
 
-      def load_answer_options(relative_path)
+      def load_answers_options(relative_path)
         data = Data.load(FilePath.init_data(relative_path))
         json = JSON.dump(data)
         options = self.class.options

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -30,7 +30,14 @@ module Underware
 
       def setup; end
 
-      def run; end
+      def run
+        # Run the domain configuration
+        configure_domain
+      end
+
+      def configure_domain
+        Configure::Domain.new(noop: true).run!([], self.class.options)
+      end
     end
   end
 end

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -39,6 +39,7 @@ module Underware
         configure_domain
         configure_login_group
         configure_login_nodes
+        template
       end
 
       private
@@ -60,6 +61,11 @@ module Underware
             [node.name], load_answer_options("nodes/gateway.yaml")
           )
         end
+      end
+
+      def template
+        reset_alces
+        new_command(Template).run!([], self.class.options)
       end
 
       def new_command(klass)

--- a/lib/underware/commands/init.rb
+++ b/lib/underware/commands/init.rb
@@ -29,6 +29,7 @@ module Underware
   module Commands
     class Init < CommandHelpers::BaseCommand
       LOGIN_GROUP = 'login'
+      NODES_GROUP = 'nodes'
 
       private
 
@@ -38,6 +39,7 @@ module Underware
         # Run the domain configuration
         configure_domain
         configure_login_group
+        configure_nodes_group
         configure_login_nodes
         template
       end
@@ -51,6 +53,12 @@ module Underware
       def configure_login_group
         new_command(Configure::Group).run!(
           [LOGIN_GROUP], load_answer_options("groups/#{LOGIN_GROUP}.yaml")
+        )
+      end
+
+      def configure_nodes_group
+        new_command(Configure::Group).run!(
+          [NODES_GROUP], load_answer_options("groups/#{NODES_GROUP}.yaml")
         )
       end
 

--- a/lib/underware/data.rb
+++ b/lib/underware/data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #==============================================================================
-# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
 #
 # This file/package is part of Alces Underware.
 #
@@ -43,6 +43,7 @@ module Underware
       def dump(data_file, data)
         raise dump_error(data) unless valid_data?(data)
         yaml = data.deep_transform_keys(&:to_s).to_yaml
+        FileUtils.mkdir_p(File.dirname(data_file))
         File.write(data_file, yaml)
         log.info "dump: #{data_file}"
       end

--- a/lib/underware/file_path.rb
+++ b/lib/underware/file_path.rb
@@ -152,6 +152,10 @@ module Underware
         File.join(keys, 'id_rsa')
       end
 
+      def init_data(relative_path)
+        File.join(internal_data_dir, 'init', relative_path)
+      end
+
       private
 
       def record(record_dir, types_dir, name)

--- a/underware.gemspec
+++ b/underware.gemspec
@@ -46,8 +46,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
 
   # Development dependencies.
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rubocop', '~> 0.52.1'
   spec.add_development_dependency 'rubocop-rspec'
 end

--- a/underware.gemspec
+++ b/underware.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
 
   # Development dependencies.
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rubocop', '~> 0.52.1'


### PR DESCRIPTION
Previously creating a new cluster was an involved process. It required running the following configure commands:
1. `configure domain`
2. `configure group login`
3. `configure node gateway`
4. `configure group nodes`

To make matters more complicated, the answers to some questions depend on the naming to other configure commands. This acts as a significant barrier to entry for new years making `underware` unusable.

This PR is a proof of concept on how these steps can be streamlined. In principle, it runs the above commands with pre-configured answers. By doing so the majority* of the questions can be skipped. The commands are still run as this ensures all the necessary files are updated (e.g. `genders`).

*The domain questions are still asked as these answers can not been known in advance. However the questions are mostly straight forward. The only exception is the build interface, put this can be addressed at a future point.

There is a bit of hackery when it comes to running multiple commands within the same process. It mainly concerns how the `BaseCommand` is initialised. In general the invocation process should be updated. An issue has been created in #51 