### PR TITLE
Create the replacement class to `nodeattr`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ PATH
       ruby-progressbar
       rubytree
       terminal-table
+      tty-config
 
 GEM
   remote: https://rubygems.org/
@@ -56,7 +57,7 @@ GEM
       dry-container (~> 0.2, >= 0.2.6)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
-    dry-types (0.13.3)
+    dry-types (0.13.4)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.4, >= 0.4.4)
@@ -73,7 +74,7 @@ GEM
     fakefs (0.18.0)
     hashie (3.6.0)
     highline (1.7.8)
-    i18n (1.2.0)
+    i18n (1.5.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     method_source (0.9.0)
@@ -122,6 +123,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
+    tty-config (0.3.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)

--- a/docs/design/multiple-clusters.md
+++ b/docs/design/multiple-clusters.md
@@ -133,3 +133,41 @@ can only change which additional groups it belongs to.
 The genders file is no longer used internally any more. However it might be used
 eternally so it needs to rendered during the `template` stage
 
+## Support Multiple Clusters
+
+The existing `FilePath` method does not work with multiple clusters as it acts
+as a global. However as everything relies on it, it can not be easily removed.
+
+Instead the `FilePath` is going to go through a staged removal. This section
+focuses on setting it up to work with a particular cluster in mind.
+
+### Step 1: Copy the over the cluster data during init
+
+The `init` process is responsible for creating a new cluster:
+
+1. Accept a `cluster_identifier` from the CLI
+2. Save it into `/var/lib/underware/etc/config.yaml`
+3. Copy the `data` directory from `/v/l/u/<cluster_identifier>`
+4. Forget that you have copied the data and continue using the original location
+   of the files for the time being
+
+### Step 2: Create the `DataPath` class
+
+This is class will be the replacement to `FilePath` for all paths that are
+cluster specific. It needs to be initialized with a cluster.
+
+1. Create the class initializing it with a cluster
+2. Create a `cache` class method that caches an instance with the current
+   `cluster_indetifier`
+3. Delegate missing methods on `FilePath` to the cached version of `DataPath`
+
+### Step 3: Move all the cluster data paths across to `DataPath`
+
+1. Move all cluster path methods onto `DataPath`, using delegation to handle
+   the move
+2. Update them to point to the new directory
+
+### Step 4: Add a command to switch the current cluster
+
+TBD
+

--- a/docs/design/multiple-clusters.md
+++ b/docs/design/multiple-clusters.md
@@ -25,85 +25,111 @@ for reference purposes only.
 
 \* Stored within a underware `config.yaml` so they can be moved
 
-# Issues
+# Refactoring
 
-The following issues will need to resolved before moving forward:
+## Remove Configure Dependency on Nodeattr
 
-1. A custom version of `nodeattr` is installed with a hard coded path to:
-   `/var/lib/underware/rendered/system/genders`
-2. The `FilePath` class stores all the different types of paths. However there
-   are now a subset of paths with specific cluster-ish behaviour
-3. Files do not have `Object` abstractions and are accessed in multiple places
-   NOTE: This means the path needs to be determined independently
-4. Paths are going to be `cluster` specific OR relative to the `data` directory
-5. Paths for multiple clusters need to be generated within the same process
-   NOTE: This is to allow `copy` functionality and prevents global vars
-6. The clustername is currently a `config/answer` value making a circular
-   reference between the file path and its content
+Currently the genders file needs to be constantly re-rendered in order for the
+configuration processes to work. This shouldn't be required as the configured
+groups should already exist.
 
-# Ideal Solution
+Instead the use of `nodeattr` or similar technologies is going to be removed
+during the configuration. It will be replaced with a "cluster data"
+configuration file which will hold all the data as `yaml`.
 
-Ideally each file type would have an object abstraction. For example, an
-`Answer` model would be responsible for answer files and similarly for a
-`Config` model etc.
+There will need to be compulsory questions during the group configure stage
+which will setup this file correctly.
 
-This would allow a mixin that implements the `ClusterPath` functionality. As
-each class is responsible for its own files, it doesn't mater if the path
-changes on a cluster basis. As long the `Answer` class can find its answers,
-anything that references `Answers` will continue working.
+### Step 1: ClusterAttr class
 
-The catch is nothing has been designed in this manner. Files are accessed in
-multiple locations as a hold over from the initial templater. Implementing this
-would require rebuilding the core internals of the `Namespace`
+This will be the abstraction to the node/group `yaml` file. It will act as the
+replacement for `nodeattr`
+*NOTE:* This object should not require access to `alces`
 
-# Compromised Solution
+1. Create the `ClusterAttr` class with basic class abilities to expand and
+   collapse node ranges
+2. Replicate the basic `GroupCache` add functionality
+3. Ensure the `orphan` group is preconfigured as the first (index 0) group
+4. Create an `add_nodes` method, supporting node ranges using the `expand`
+   method
+5. Allow nodes to be added to `groups` with `add_nodes`
+6. Prevent a node being added twice
+7. `groups_hash` method that returns: `{ group_name => index }`
 
-The core issues atm is that paths are essentially global. They are all accessed
-with methods like `FilePath.domain_answers`. This leaves little room to
-manoeuvre when it comes to generating cluster specific paths.
+*NOTE*: The remove functionality can be skipped for this first pass
 
-The core component that needs to change is the `internal_data_dir` is going to
-become cluster specific. However this can not be done with a global variable as
-this will prevent generating paths for multiple clusters within the same
-process. Doing so would kill all ability to `copy` cluster files.
+The yaml file should have the following structure:
 
-Following a similar design pattern, there needs to be a `Content::Path` like
-object. It will be initialized with the relevant cluster
-(e.g. `Content::Path.new(cluster: cluster_name)`). This will make all its paths
-cluster specific and solves the global issue.
+```YAML
+groups:
+  - orphan # Must be the first group automagically (can the user change this?)
+  - group1
+  - group2
+  -        # A blank index indicates a delet group (TBA)
+  - group4
 
-The relevant classes can then determine the file path as long as they have
-access to the clustername. This can be resolved by storing it on the main
-`alces` namespace.
+# The node names are not used as keys as this is nightmare to validate
+# NOTE: A node can only appear once within the list
+nodes:
+  - nodes: collapsed_node_names
+    groups: [primary_group, .. other groups ..]
+```
 
-# Implementation
+### Step 2: Connect the ClusterAttr into the Namespace
 
-0. Wrap `alces.domain.config.clustername` as `alces.clustername`
-1. Create the `Content::Path` object with the `cluster` initialization
-2. Move all the relevant paths onto `Content::Path` ignoring the cluster
-  1. Add a path to `Content::Path` delegating it back to `FilePath`
-  2. Replaces all references to the `FilePath.method` to `Content::Path`
-  3. Implement the method on `Content::Path` ignoring the cluster
-  4. Remove the method off `FilePath`
-  5. Repeat relevant steps for the remaining paths
-3. Update the `NodeattrInterface` to use cluster specific paths
-  1. Create a `NodeattrInterface` instance class that is initialized with
-   the file path
-  2. Delegate the instance methods to the class methods
-  3. Change all external references to the class to the instance
-  4. Move the class methods onto the instance
-  5. Call `nodeattr` with a `-f file` flag pointing to the correct path
-4. Add scoping to specify a current cluster so it doesn't need to be
-   include with every `CLI` command.
-  1. Add a change scope command which takes a simple string input
-  2. Initialize the `alces` namespace with this input
-  3. Use this input to in `alces.clustername` 
-  4. Remove the `clustername` question from configuration
-5. Update the `Content::Path` method to point all the paths to the cluster
-   specific
-   NOTE: This will require manually copying some of the `data` directory to
-   `var` so it continues to work. This will break all the `specs` which need
-   to be resolved
-6. Add a `Content::Path.new` method that points to the `data` directory
-7. Update the `init` command to copy the files from `data` into `var`
+At this point the cluster attributes need to be connected into the namespace.
+This will temporarily prevent anything from being configured with underware
+
+1. Create a mechanism for adding new groups/nodes within the specs
+2. Add an instance of `ClusterAttr` onto the namespace
+3. Build the list of `groups` using the `cluster_attr`
+4. Update `orphan_list`
+5. Remove `group_cache` off the namespace
+
+### Step 3: Revamp the entire configuration process
+
+The `Configurator` class is rather complicated as it is responsible for
+creating groups in addition to asking questions and saving answers. Instead,
+groups will be created within the commands themselves. This limits the
+`Configurator` scope to only asking questions and saving answers
+
+1. Remove all "group_cache" related code from the `Configurator`. Skipping
+   any `command` specs that break as a result
+2. Remove any orphan related code, this should be done within `configure node`
+3. Create the `group` in `configure command`
+4. Add mandatory questions to `configure group` (see below)
+5. Update `ClusterAttr` based on mandatory questions in `configure group`
+6. Create orphan node in `configure node` if required
+5. Add mandatory question to `configure node`
+6. Update `ClusterAttr` based on mandatory questions in `configure node`
+5. Remove duplication due to mandatory questions
+
+#### Mandatory Questions
+
+As `configure.yaml` is becoming user content, `underware` can not rely on it
+being correct. Instead there are going to be mandatory questions which will
+always be asked.
+
+As the `configure.yaml` file is consider an unsafe source, these questions will
+not have defaults unless they have already been asked. This can be resolved in
+the future (domain level mandatory questions?).
+
+**Group:**
+The group name to be created is give from the CLI, so this is fine. However
+a group must contain `nodes` which may contain other groups. So the following
+questions should be asked:
+
+1. List of nodes within the `group` (e.g. blah)?
+2. Additional groups these nodes belong to?
+
+**Node:**
+In this case the node has already been configured within a group. As such it
+can only change which additional groups it belongs to.
+
+1. Reask the additional groups question
+
+#### Step 4: Render the genders file during template
+
+The genders file is no longer used internally any more. However it might be used
+eternally so it needs to rendered during the `template` stage
 

--- a/docs/design/multiple-clusters.md
+++ b/docs/design/multiple-clusters.md
@@ -1,0 +1,108 @@
+# Aim
+
+The internal paths are going to be revamped to allow rendering of multiple
+clusters. This will allow any cluster specific configuration to live within
+the `/var/lib` directory. This makes the internal `data` directory static
+for reference purposes only.
+
+# Requirements
+
+1. Allow rendering of multiple independent clusters,
+2. Store each cluster within the `/var/lib/underware/<cluster-name>`\*
+3. Use the `<install-dir>/data` directory as a base reference only. It should
+   never be edited w/o checking it into the repo
+4. Update the `init` process to create a new repo from the `data`
+5. All "content" type files should be cluster specific. This includes but is
+   not limited to:
+   a. `configs`
+   b. `answers`
+   c. `configure.yaml`
+   d. `templates`
+   e. `genders`
+   f. `rendered`
+   g. `build files`?
+
+\* Stored within a underware `config.yaml` so they can be moved
+
+# Issues
+
+The following issues will need to resolved before moving forward:
+
+1. A custom version of `nodeattr` is installed with a hard coded path to:
+   `/var/lib/underware/rendered/system/genders`
+2. The `FilePath` class stores all the different types of paths. However there
+   are now a subset of paths with specific cluster-ish behaviour
+3. Files do not have `Object` abstractions and are accessed in multiple places
+   NOTE: This means the path needs to be determined independently
+4. Paths are going to be `cluster` specific OR relative to the `data` directory
+5. Paths for multiple clusters need to be generated within the same process
+   NOTE: This is to allow `copy` functionality and prevents global vars
+6. The clustername is currently a `config/answer` value making a circular
+   reference between the file path and its content
+
+# Ideal Solution
+
+Ideally each file type would have an object abstraction. For example, an
+`Answer` model would be responsible for answer files and similarly for a
+`Config` model etc.
+
+This would allow a mixin that implements the `ClusterPath` functionality. As
+each class is responsible for its own files, it doesn't mater if the path
+changes on a cluster basis. As long the `Answer` class can find its answers,
+anything that references `Answers` will continue working.
+
+The catch is nothing has been designed in this manner. Files are accessed in
+multiple locations as a hold over from the initial templater. Implementing this
+would require rebuilding the core internals of the `Namespace`
+
+# Compromised Solution
+
+The core issues atm is that paths are essentially global. They are all accessed
+with methods like `FilePath.domain_answers`. This leaves little room to
+manoeuvre when it comes to generating cluster specific paths.
+
+The core component that needs to change is the `internal_data_dir` is going to
+become cluster specific. However this can not be done with a global variable as
+this will prevent generating paths for multiple clusters within the same
+process. Doing so would kill all ability to `copy` cluster files.
+
+Following a similar design pattern, there needs to be a `Content::Path` like
+object. It will be initialized with the relevant cluster
+(e.g. `Content::Path.new(cluster: cluster_name)`). This will make all its paths
+cluster specific and solves the global issue.
+
+The relevant classes can then determine the file path as long as they have
+access to the clustername. This can be resolved by storing it on the main
+`alces` namespace.
+
+# Implementation
+
+0. Wrap `alces.domain.config.clustername` as `alces.clustername`
+1. Create the `Content::Path` object with the `cluster` initialization
+2. Move all the relevant paths onto `Content::Path` ignoring the cluster
+  a. Add a path to `Content::Path` delegating it back to `FilePath`
+  b. Replaces all references to the `FilePath.method` to `Content::Path`
+  c. Implement the method on `Content::Path` ignoring the cluster
+  d. Remove the method off `FilePath`
+  e. Repeat a-d for the remaining paths
+3. Update the `NodeattrInterface` to use cluster specific paths
+  a. Create a `NodeattrInterface` instance class that is initialized with
+     the file path
+  b. Delegate the instance methods to the class methods
+  c. Change all external references to the class to the instance
+  d. Move the class methods onto the instance
+  c. Call `nodeattr` with a `-f file` flag pointing to the correct path
+4. Add scoping to specify a current cluster so it doesn't need to be
+   include with every `CLI` command.
+  a. Add a change scope command which takes a simple string input
+  b. Initialize the `alces` namespace with this input
+  c. Use this input to in `alces.clustername` 
+  d. Remove the `clustername` question from configuration
+5. Update the `Content::Path` method to point all the paths to the cluster
+   specific
+   NOTE: This will require manually copying some of the `data` directory to
+   `var` so it continues to work. This will break all the `specs` which need
+   to be resolved
+6. Add a `Content::Path.new` method that points to the `data` directory
+7. Update the `init` command to copy the files from `data` into `var`
+

--- a/docs/design/multiple-clusters.md
+++ b/docs/design/multiple-clusters.md
@@ -14,13 +14,14 @@ for reference purposes only.
 4. Update the `init` process to create a new repo from the `data`
 5. All "content" type files should be cluster specific. This includes but is
    not limited to:
-   a. `configs`
-   b. `answers`
-   c. `configure.yaml`
-   d. `templates`
-   e. `genders`
-   f. `rendered`
-   g. `build files`?
+  1. `configs`
+  2. `answers`
+  3. `configure.yaml`
+  4. `templates`
+  5. `genders`
+  6. `rendered`
+  7. `build files`?
+  8. `group_cache`
 
 \* Stored within a underware `config.yaml` so they can be moved
 
@@ -80,24 +81,24 @@ access to the clustername. This can be resolved by storing it on the main
 0. Wrap `alces.domain.config.clustername` as `alces.clustername`
 1. Create the `Content::Path` object with the `cluster` initialization
 2. Move all the relevant paths onto `Content::Path` ignoring the cluster
-  a. Add a path to `Content::Path` delegating it back to `FilePath`
-  b. Replaces all references to the `FilePath.method` to `Content::Path`
-  c. Implement the method on `Content::Path` ignoring the cluster
-  d. Remove the method off `FilePath`
-  e. Repeat a-d for the remaining paths
+  1. Add a path to `Content::Path` delegating it back to `FilePath`
+  2. Replaces all references to the `FilePath.method` to `Content::Path`
+  3. Implement the method on `Content::Path` ignoring the cluster
+  4. Remove the method off `FilePath`
+  5. Repeat relevant steps for the remaining paths
 3. Update the `NodeattrInterface` to use cluster specific paths
-  a. Create a `NodeattrInterface` instance class that is initialized with
-     the file path
-  b. Delegate the instance methods to the class methods
-  c. Change all external references to the class to the instance
-  d. Move the class methods onto the instance
-  c. Call `nodeattr` with a `-f file` flag pointing to the correct path
+  1. Create a `NodeattrInterface` instance class that is initialized with
+   the file path
+  2. Delegate the instance methods to the class methods
+  3. Change all external references to the class to the instance
+  4. Move the class methods onto the instance
+  5. Call `nodeattr` with a `-f file` flag pointing to the correct path
 4. Add scoping to specify a current cluster so it doesn't need to be
    include with every `CLI` command.
-  a. Add a change scope command which takes a simple string input
-  b. Initialize the `alces` namespace with this input
-  c. Use this input to in `alces.clustername` 
-  d. Remove the `clustername` question from configuration
+  1. Add a change scope command which takes a simple string input
+  2. Initialize the `alces` namespace with this input
+  3. Use this input to in `alces.clustername` 
+  4. Remove the `clustername` question from configuration
 5. Update the `Content::Path` method to point all the paths to the cluster
    specific
    NOTE: This will require manually copying some of the `data` directory to

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -35,9 +35,11 @@ module Underware
       def update(*a)
         new(*a).tap do |attr|
           attr.__data__.read unless attr.__data__.source_file.nil?
+          yield attr if block_given?
           attr.__data__.write(force: true)
         end
       end
+      alias_method :load, :update
     end
 
     attr_reader :cluster, :__data__

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -45,7 +45,7 @@ module Underware
 
     def setup
       config.set_if_empty(:groups, value: ['orphan'])
-      config.set_if_empty(:nodes, value: [])
+      config.set_if_empty(:nodes, value: {})
     end
 
     def raw_groups
@@ -53,20 +53,26 @@ module Underware
     end
 
     def raw_nodes
-      config.fetch(:nodes)
+      config.fetch(:nodes).keys
     end
 
     def group_index(group)
       raw_groups.find_index(group)
     end
 
+    def groups_for_node(node)
+      config.fetch(:nodes, node)
+    end
+
     def add_group(group_name)
       config.append(group_name, to: :groups)
     end
 
-    def add_nodes(node_string)
-      node_array = self.class.expand(node_string)
-      config.append(*node_array, to: :nodes)
+    def add_nodes(node_string, groups: [])
+      groups = Array.wrap(groups)
+      self.class.expand(node_string).each do |node|
+        config.set(:nodes, node, value: groups)
+      end
     end
 
     private

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -71,6 +71,7 @@ module Underware
     def add_nodes(node_string, groups: [])
       groups = Array.wrap(groups)
       self.class.expand(node_string).each do |node|
+        raise_error_if_node_exists(node)
         config.set(:nodes, node, value: groups)
       end
     end
@@ -78,5 +79,13 @@ module Underware
     private
 
     attr_reader :config
+
+    def raise_error_if_node_exists(node)
+      if config.fetch(:nodes, node)
+        raise ExistingNodeError, <<~ERROR
+          Failed to add node as it already exists: '#{node}'
+        ERROR
+      end
+    end
   end
 end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -29,5 +29,11 @@ module Underware
     def initialize(cluster)
       @cluster = cluster
     end
+
+    private
+
+    def path
+      File.join(FilePath.internal_data_dir, 'cluster_attributes.yaml')
+    end
   end
 end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -40,6 +40,7 @@ module Underware
       @config = TTY::Config.new
       config.prepend_path(FilePath.internal_data_dir)
       config.filename = 'cluster-attributes'
+      config.set_if_empty(:groups, value: ['orphan'])
     end
 
     def raw_groups

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -47,6 +47,10 @@ module Underware
       config.fetch(:groups)
     end
 
+    def group_index(group)
+      raw_groups.find_index(group)
+    end
+
     def add_group(group_name)
       config.append(group_name, to: :groups)
     end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -40,7 +40,12 @@ module Underware
       @config = TTY::Config.new
       config.prepend_path(FilePath.internal_data_dir)
       config.filename = 'cluster-attributes'
+      setup
+    end
+
+    def setup
       config.set_if_empty(:groups, value: ['orphan'])
+      config.set_if_empty(:nodes, value: [])
     end
 
     def raw_groups
@@ -48,7 +53,7 @@ module Underware
     end
 
     def raw_nodes
-      []
+      config.fetch(:nodes)
     end
 
     def group_index(group)
@@ -57,6 +62,11 @@ module Underware
 
     def add_group(group_name)
       config.append(group_name, to: :groups)
+    end
+
+    def add_nodes(node_string)
+      node_array = self.class.expand(node_string)
+      config.append(*node_array, to: :nodes)
     end
 
     private

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -47,6 +47,10 @@ module Underware
       config.fetch(:groups)
     end
 
+    def raw_nodes
+      []
+    end
+
     def group_index(group)
       raw_groups.find_index(group)
     end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -34,32 +34,32 @@ module Underware
 
       def update(*a)
         new(*a).tap do |cluster_attr|
-          cluster_attr.config.write
+          cluster_attr.__data__.write
         end
       end
     end
 
-    attr_reader :cluster, :config
+    attr_reader :cluster, :__data__
 
     def initialize(cluster)
       @cluster = cluster
-      @config = TTY::Config.new
-      config.prepend_path(FilePath.internal_data_dir)
-      config.filename = 'cluster-attributes'
+      @__data__ = TTY::Config.new
+      __data__.prepend_path(FilePath.internal_data_dir)
+      __data__.filename = 'cluster-attributes'
       setup
     end
 
     def setup
-      config.set_if_empty(:groups, value: ['orphan'])
-      config.set_if_empty(:nodes, value: {})
+      __data__.set_if_empty(:groups, value: ['orphan'])
+      __data__.set_if_empty(:nodes, value: {})
     end
 
     def raw_groups
-      config.fetch(:groups)
+      __data__.fetch(:groups)
     end
 
     def raw_nodes
-      config.fetch(:nodes).keys
+      __data__.fetch(:nodes).keys
     end
 
     def group_index(group)
@@ -67,26 +67,26 @@ module Underware
     end
 
     def groups_for_node(node)
-      config.fetch(:nodes, node)
+      __data__.fetch(:nodes, node)
     end
 
     def add_group(group_name)
       raise_error_if_group_exists(group_name)
-      config.append(group_name, to: :groups)
+      __data__.append(group_name, to: :groups)
     end
 
     def add_nodes(node_string, groups: [])
       groups = Array.wrap(groups)
       self.class.expand(node_string).each do |node|
         raise_error_if_node_exists(node)
-        config.set(:nodes, node, value: groups)
+        __data__.set(:nodes, node, value: groups)
       end
     end
 
     private
 
     def raise_error_if_node_exists(node)
-      if config.fetch(:nodes, node)
+      if __data__.fetch(:nodes, node)
         raise ExistingNodeError, <<~ERROR
           Failed to add node as it already exists: '#{node}'
         ERROR
@@ -94,7 +94,7 @@ module Underware
     end
 
     def raise_error_if_group_exists(group)
-      if config.fetch(:groups).include?(group)
+      if __data__.fetch(:groups).include?(group)
         raise ExistingGroupError, <<~ERROR
           Failed to add group as it already exists: '#{group}'
         ERROR

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Underware.
+#
+# Alces Underware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Underware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Underware, please visit:
+# https://github.com/alces-software/underware
+#==============================================================================
+
+module Underware
+  class ClusterAttr
+    attr_reader :cluster
+
+    def initialize(cluster)
+      @cluster = cluster
+    end
+  end
+end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -65,6 +65,7 @@ module Underware
     end
 
     def add_group(group_name)
+      raise_error_if_group_exists(group_name)
       config.append(group_name, to: :groups)
     end
 
@@ -84,6 +85,14 @@ module Underware
       if config.fetch(:nodes, node)
         raise ExistingNodeError, <<~ERROR
           Failed to add node as it already exists: '#{node}'
+        ERROR
+      end
+    end
+
+    def raise_error_if_group_exists(group)
+      if config.fetch(:groups).include?(group)
+        raise ExistingGroupError, <<~ERROR
+          Failed to add group as it already exists: '#{group}'
         ERROR
       end
     end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -33,8 +33,9 @@ module Underware
       end
 
       def update(*a)
-        new(*a).tap do |cluster_attr|
-          cluster_attr.__data__.write
+        new(*a).tap do |attr|
+          attr.__data__.read unless attr.__data__.source_file.nil?
+          attr.__data__.write(force: true)
         end
       end
     end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -23,6 +23,7 @@
 #==============================================================================
 
 require 'underware/cluster_attr/expand'
+require 'tty/config'
 
 module Underware
   class ClusterAttr
@@ -36,12 +37,21 @@ module Underware
 
     def initialize(cluster)
       @cluster = cluster
+      @config = TTY::Config.new
+      config.prepend_path(FilePath.internal_data_dir)
+      config.filename = 'cluster-attributes'
+    end
+
+    def raw_groups
+      config.fetch(:groups)
+    end
+
+    def add_group(group_name)
+      config.append(group_name, to: :groups)
     end
 
     private
 
-    def path
-      File.join(FilePath.internal_data_dir, 'cluster_attributes.yaml')
-    end
+    attr_reader :config
   end
 end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -32,8 +32,9 @@ module Underware
         'cluster-attributes'
       end
 
-      def expand(nodes_string)
-        Expand.explode_nodes(nodes_string)
+      def expand(nodes)
+        # Do not expand single nodes as the libray can not handle it
+        nodes.include?('[') ? Expand.explode_nodes(nodes) : [nodes]
       end
 
       def update(*a)

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -31,9 +31,15 @@ module Underware
       def expand(nodes_string)
         Expand.explode_nodes(nodes_string)
       end
+
+      def update(*a)
+        new(*a).tap do |cluster_attr|
+          cluster_attr.config.write
+        end
+      end
     end
 
-    attr_reader :cluster
+    attr_reader :cluster, :config
 
     def initialize(cluster)
       @cluster = cluster
@@ -78,8 +84,6 @@ module Underware
     end
 
     private
-
-    attr_reader :config
 
     def raise_error_if_node_exists(node)
       if config.fetch(:nodes, node)

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -52,7 +52,7 @@ module Underware
     def initialize(cluster)
       @cluster = cluster
       @__data__ = TTY::Config.new
-      __data__.prepend_path(FilePath.internal_data_dir)
+      __data__.prepend_path(FilePath.underware_storage)
       __data__.filename = self.class.filename
       setup
     end

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -22,8 +22,16 @@
 # https://github.com/alces-software/underware
 #==============================================================================
 
+require 'underware/cluster_attr/expand'
+
 module Underware
   class ClusterAttr
+    class << self
+      def expand(nodes_string)
+        Expand.explode_nodes(nodes_string)
+      end
+    end
+
     attr_reader :cluster
 
     def initialize(cluster)

--- a/lib/underware/cluster_attr.rb
+++ b/lib/underware/cluster_attr.rb
@@ -28,6 +28,10 @@ require 'tty/config'
 module Underware
   class ClusterAttr
     class << self
+      def filename
+        'cluster-attributes'
+      end
+
       def expand(nodes_string)
         Expand.explode_nodes(nodes_string)
       end
@@ -48,7 +52,7 @@ module Underware
       @cluster = cluster
       @__data__ = TTY::Config.new
       __data__.prepend_path(FilePath.internal_data_dir)
-      __data__.filename = 'cluster-attributes'
+      __data__.filename = self.class.filename
       setup
     end
 

--- a/lib/underware/cluster_attr/expand.rb
+++ b/lib/underware/cluster_attr/expand.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+##
+# This module has been adapted from the Nodeattr Gem by Doug Everly, 2013
+# https://github.com/DougEverly/nodeattr
+#
+
+# Copyright (c) 2013 Doug Everly
+
+# MIT License
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+module Underware
+  class ClusterAttr
+    class Expand
+      class << self
+        def explode_nodes(nodes)
+          h = Array.new
+          m = nodes.match(/^(.*)\[(.*)\]$/)
+          if m
+            base = m[1]
+            instances = m[2].split(',')
+            instances.each do |i|
+              if i.match(/-/)
+                left, right = i.split('-')
+                padding = left.match(/^0+/)
+                (left.to_i .. right.to_i).each do |j|
+                  h << sprintf("%s%0#{padding.to_s.length + 1}d", base, j)
+                end
+              else
+                padding = i.match(/^0+/).size - 1
+                if padding.size > 1
+                  pad = '0' * (padding.size -1)
+                end
+                h << sprintf("%s%0#{padding.to_s.length + 1}d", base, j)
+              end
+            end
+          end
+          h
+        end
+      end
+    end
+  end
+end

--- a/lib/underware/exceptions.rb
+++ b/lib/underware/exceptions.rb
@@ -87,4 +87,7 @@ module Underware
 
   class ExistingNodeError < UserUnderwareError
   end
+
+  class ExistingGroupError < UserUnderwareError
+  end
 end

--- a/lib/underware/exceptions.rb
+++ b/lib/underware/exceptions.rb
@@ -84,4 +84,7 @@ module Underware
   # Alias for Exception to use to indicate we want to catch everything, and to
   # also tell Rubocop to be quiet about this.
   IntentionallyCatchAnyException = Exception
+
+  class ExistingNodeError < UserUnderwareError
+  end
 end

--- a/lib/underware/namespaces/alces.rb
+++ b/lib/underware/namespaces/alces.rb
@@ -55,6 +55,10 @@ module Underware
         @stacks_hash = {}
       end
 
+      def cluster_identifier
+        'placeholder-cluster-identifier'
+      end
+
       def domain
         @domain ||= Namespaces::Domain.new(alces)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,9 @@ require 'underware/cli'
 require 'underware/spec/spec_utils'
 require 'filesystem'
 
+require 'pry'
+require 'pry-byebug'
+
 FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 
 

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Underware::ClusterAttr do
 
     let(:node_str) { 'node[01-10]' }
     let(:nodes) { described_class.expand(node_str) }
+    let(:node_groups) { nil }
 
     before do
       if node_groups
@@ -101,9 +102,15 @@ RSpec.describe Underware::ClusterAttr do
       end
     end
 
-    context 'without any groups' do
-      let(:node_groups) { nil }
+    describe '#add_nodes' do
+      it 'errors if a node is re-added' do
+        expect do
+          subject.add_nodes(node_str)
+        end.to raise_error(Underware::ExistingNodeError)
+      end
+    end
 
+    context 'without any groups' do
       describe '#raw_nodes' do
         it 'returns the node list' do
           expect(subject.raw_nodes).to contain_exactly(*nodes)

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Underware::ClusterAttr do
     subject { described_class.new(cluster_name) }
   end
 
+  shared_context 'with the first group' do
+    include_context 'with a ClusterAttr instance'
+
+    let(:first_group) { 'my-first-group' }
+    before { subject.add_group(first_group) }
+  end
+
   describe '::expand' do
     it 'can expand multiple nodes' do
       node_str = 'node[01-10]'
@@ -60,15 +67,17 @@ RSpec.describe Underware::ClusterAttr do
   end
 
   context 'when adding a single group' do
-    include_context 'with a ClusterAttr instance'
-
-    let(:first_group) { 'my-first-group' }
-
-    before { subject.add_group(first_group) }
+    include_context 'with the first group'
 
     describe '#raw_groups' do
       it 'adds the group' do
         expect(subject.raw_groups).to include(first_group)
+      end
+    end
+
+    describe '#raw_nodes' do
+      it 'returns and empty array' do
+        expect(subject.raw_nodes).to eq([])
       end
     end
 

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe Underware::ClusterAttr do
                       .push('node10')
       expect(described_class.expand(node_str)).to contain_exactly(*nodes)
     end
+
+    it 'can expand a single node' do
+      node = 'node01'
+      expect(described_class.expand(node)).to contain_exactly(node)
+    end
   end
 
   describe '::update' do

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -25,4 +25,12 @@
 require 'underware/cluster_attr'
 
 RSpec.describe Underware::ClusterAttr do
+  describe '::expand' do
+    it 'can expand multiple nodes' do
+      node_str = 'node[01-10]'
+      nodes = (1...10).map { |i| "node0#{i}" }
+                      .push('node10')
+      expect(described_class.expand(node_str)).to contain_exactly(*nodes)
+    end
+  end
 end

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -42,8 +42,20 @@ RSpec.describe Underware::ClusterAttr do
   context 'without any additional groups' do
     include_context 'with a ClusterAttr instance'
 
-    it 'contains the orphan group' do
-      expect(subject.raw_groups).to include('orphan')
+    describe '#raw_groups' do
+      it 'contains the orphan group' do
+        expect(subject.raw_groups).to include('orphan')
+      end
+    end
+
+    describe '#group_index' do
+      it 'returns nil for missing groups' do
+        expect(subject.group_index('some-missing-group')).to eq(nil)
+      end
+
+      it 'returns 0 for the orphan group' do
+        expect(subject.group_index('orphan')).to eq(0)
+      end
     end
   end
 
@@ -54,8 +66,16 @@ RSpec.describe Underware::ClusterAttr do
 
     before { subject.add_group(first_group) }
 
-    it 'adds the group' do
-      expect(subject.raw_groups).to include(first_group)
+    describe '#raw_groups' do
+      it 'adds the group' do
+        expect(subject.raw_groups).to include(first_group)
+      end
+    end
+
+    describe '#group_index' do
+      it 'returns 1 for the first group' do
+        expect(subject.group_index(first_group)).to eq(1)
+      end
     end
   end
 end

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Underware::ClusterAttr do
   describe '::update' do
     include_context 'with a ClusterAttr instance'
 
-    let(:path) { subject.config.source_file }
+    let(:path) { subject.__data__.source_file }
 
     it 'writes the file if it does not already exist' do
       described_class.update(subject.cluster)

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Underware::ClusterAttr do
     end
   end
 
+  context 'without any additional groups' do
+    include_context 'with a ClusterAttr instance'
+
+    it 'contains the orphan group' do
+      expect(subject.raw_groups).to include('orphan')
+    end
+  end
+
   context 'when adding a single group' do
     include_context 'with a ClusterAttr instance'
 

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe Underware::ClusterAttr do
     it 'returns the instance' do
       expect(described_class.update(subject.cluster)).to be_a(described_class)
     end
+
+    describe 'with an existing group' do
+      include_context 'with a ClusterAttr instance'
+      include_context 'with the first group'
+
+      before { subject.__data__.write }
+
+      it 'preserves the existing data' do
+        new_attr = described_class.update(subject.cluster)
+        expect(new_attr.raw_groups).to eq(subject.raw_groups)
+      end
+    end
   end
 
   context 'without any additional groups' do

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Underware::ClusterAttr do
     include_context 'with the first group'
 
     describe '#raw_groups' do
-      it 'adds the group' do
+      it 'contains the group' do
         expect(subject.raw_groups).to include(first_group)
       end
     end
@@ -84,6 +84,20 @@ RSpec.describe Underware::ClusterAttr do
     describe '#group_index' do
       it 'returns 1 for the first group' do
         expect(subject.group_index(first_group)).to eq(1)
+      end
+    end
+  end
+
+  context 'when adding nodes to the first group' do
+    include_context 'with the first group'
+
+    let(:node_str) { 'node[01-10]' }
+    let(:nodes) { described_class.expand(node_str) }
+    before { subject.add_nodes(node_str) }
+
+    describe '#raw_nodes' do
+      it 'returns the node list' do
+        expect(subject.raw_nodes).to contain_exactly(*nodes)
       end
     end
   end

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe Underware::ClusterAttr do
     end
   end
 
+  describe '::update' do
+    include_context 'with a ClusterAttr instance'
+
+    let(:path) { subject.config.source_file }
+
+    it 'writes the file if it does not already exist' do
+      described_class.update(subject.cluster)
+      expect(File.exists?(path)).to be true
+    end
+
+    it 'returns the instance' do
+      expect(described_class.update(subject.cluster)).to be_a(described_class)
+    end
+  end
+
   context 'without any additional groups' do
     include_context 'with a ClusterAttr instance'
 

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Underware.
+#
+# Alces Underware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Underware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Underware, please visit:
+# https://github.com/alces-software/underware
+#==============================================================================
+
+require 'underware/cluster_attr'
+
+RSpec.describe Underware::ClusterAttr do
+end

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe Underware::ClusterAttr do
       expect(described_class.update(subject.cluster)).to be_a(described_class)
     end
 
+    it 'updates the config for future reference' do
+      new_group = 'my-new-group'
+      described_class.update(subject.cluster) { |a| a.add_group(new_group) }
+      expect(described_class.load(subject.cluster).raw_groups).to include(new_group)
+    end
+
     describe 'with an existing group' do
       include_context 'with a ClusterAttr instance'
       include_context 'with the first group'

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -25,12 +25,29 @@
 require 'underware/cluster_attr'
 
 RSpec.describe Underware::ClusterAttr do
+  shared_context 'with a ClusterAttr instance' do
+    let(:cluster_name) { 'my-test-cluster' }
+    subject { described_class.new(cluster_name) }
+  end
+
   describe '::expand' do
     it 'can expand multiple nodes' do
       node_str = 'node[01-10]'
       nodes = (1...10).map { |i| "node0#{i}" }
                       .push('node10')
       expect(described_class.expand(node_str)).to contain_exactly(*nodes)
+    end
+  end
+
+  context 'when adding a single group' do
+    include_context 'with a ClusterAttr instance'
+
+    let(:first_group) { 'my-first-group' }
+
+    before { subject.add_group(first_group) }
+
+    it 'adds the group' do
+      expect(subject.raw_groups).to include(first_group)
     end
   end
 end

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Underware::ClusterAttr do
       expect(described_class.load(subject.cluster).raw_groups).to include(new_group)
     end
 
-    describe 'with an existing group' do
+    context 'with an existing group' do
       include_context 'with a ClusterAttr instance'
       include_context 'with the first group'
 

--- a/spec/underware/cluster_attr_spec.rb
+++ b/spec/underware/cluster_attr_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Underware::ClusterAttr do
     include_context 'with a ClusterAttr instance'
     include_context 'with the first group'
 
+    describe '#add_group' do
+      it 'errors when adding an existing group' do
+        expect do
+          subject.add_group(first_group)
+        end.to raise_error(Underware::ExistingGroupError)
+      end
+    end
+
     describe '#raw_groups' do
       it 'contains the group' do
         expect(subject.raw_groups).to include(first_group)

--- a/underware.gemspec
+++ b/underware.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ruby-progressbar'
   spec.add_runtime_dependency 'rubytree'
   spec.add_runtime_dependency 'terminal-table'
+  spec.add_runtime_dependency 'tty-config'
 
   # Test dependencies.
   spec.add_development_dependency 'fakefs'


### PR DESCRIPTION
Based on #54

This PR implements the new `ClusterAttr` which will eventually replace `nodeattr`. It stores all the groups and nodes in a single file. It will also be taking over the functionality of `GroupCache`, making it the definitive location for `node`/`group` information.

It is built on `TTY::Config` as it makes it easy to set/ fetch variables without having to worry if the hash has already been setup or if the keys are strings or symbols.