### PR TITLE
Use Question for SSH Keys

### DIFF
--- a/data/base/configs/domain.yaml
+++ b/data/base/configs/domain.yaml
@@ -6,8 +6,7 @@ debug: true
 cluster: '<%= answer.cluster_name %>'
 root_password: '<%= answer.root_password %>'
 configured_build_interface: '<%= answer.configured_build_interface %>'
-publickey: '<%= domain.keys.public %>'
-privatekey: '<%= domain.keys.private %>'
+publickey: '<%= answer.root_ssh_key %>'
 role: '<%=answer.role%>'
 
 

--- a/data/base/configure.yaml
+++ b/data/base/configure.yaml
@@ -11,6 +11,10 @@ questions:
     question: 'Password to use for root user'
     type: password
 
+  - &root_ssh_key
+    identifier: root_ssh_key
+    question: "Root user SSH key (in the format 'ssh-rsa <key data> user@host')"
+
   - &configured_build_interface
     identifier: configured_build_interface
     question: 'Interface of this machine that the cluster should be built on (will determine IP of this machine to use when templating)'

--- a/data/base/configure.yaml
+++ b/data/base/configure.yaml
@@ -63,6 +63,7 @@ domain:
   # BASE
   - *cluster_name
   - *root_password
+  - *root_ssh_key
   - *configured_build_interface
 
   # NETWORKS

--- a/data/base/templates/content/node/base/main.sh
+++ b/data/base/templates/content/node/base/main.sh
@@ -3,12 +3,13 @@
 
 mkdir -p /root/.ssh
 chmod 600 /root/.ssh
-echo <%= config.publickey %> > /root/.ssh/authorized_keys
-cat << EOF > /root/.ssh/id_rsa
-<%= config.privatekey %>
-EOF
-chmod 600 /root/.ssh/id_rsa
+echo <%= config.publickey %> >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
+# This has been commented out until a clearer solution for SSH key generation has been determined
+#cat << EOF > /root/.ssh/id_rsa
+#<%= config.privatekey %>
+#EOF
+#chmod 600 /root/.ssh/id_rsa
 sed -i 's/^PasswordAuthentication.*$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 systemctl restart sshd
 

--- a/lib/underware/data_path.rb
+++ b/lib/underware/data_path.rb
@@ -51,9 +51,7 @@ module Underware
 
     # Generate static path methods
     {
-      configure: 'configure.yaml',
-      public_key: ['keys', 'id_rsa.pub'],
-      private_key: ['keys', 'id_rsa']
+      configure: 'configure.yaml'
     }.each do |method, path|
       define_method(method) { join(*Array.wrap(path)) }
     end

--- a/lib/underware/namespaces/domain.rb
+++ b/lib/underware/namespaces/domain.rb
@@ -16,17 +16,10 @@ module Underware
         @genders_url ||= DeploymentServer.system_file_url('genders')
       end
 
-      def keys
-        KeyPair.new(
-          File.read(FilePath.public_key),
-          File.read(FilePath.private_key)
-        )
-      end
-
       private
 
       def white_list_for_hasher
-        super.concat [:hostip, :hosts_url, :genders_url, :keys]
+        super.concat [:hostip, :hosts_url, :genders_url]
       end
 
       def additional_dynamic_namespace

--- a/spec/underware/namespaces/domain_spec.rb
+++ b/spec/underware/namespaces/domain_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe Underware::Namespaces::Domain do
 
     include_examples Underware::Namespaces::HashMergerNamespace
 
-    before :each do
-      # Create key pair files here (in production created on install), both so
-      # can test in `#keys` (below) and so `HashMergerNamespace#to_h` tests
-      # pass as key values will be included in hashed domain.
-      Underware::Utils.create_file(
-        Underware::FilePath.private_key, content: 'my_private_key'
-      )
-      Underware::Utils.create_file(
-        Underware::FilePath.public_key, content: 'my_public_key'
-      )
-    end
-
     context 'with mocked ip' do
       let(:ip) { '1.2.3.4' }
 
@@ -44,26 +32,6 @@ RSpec.describe Underware::Namespaces::Domain do
       it 'has a genders_url' do
         url = "http://#{ip}/metalware/system/genders"
         expect(subject.genders_url).to eq(url)
-      end
-    end
-
-    describe '#keys' do
-      describe '#private' do
-        it 'provides access to private key from file' do
-
-          expect(subject.keys.private).to eq('my_private_key')
-        end
-      end
-
-      describe '#public' do
-        it 'provides access to public key from file' do
-
-          expect(subject.keys.public).to eq('my_public_key')
-        end
-      end
-
-      it 'errors if attempt to access any other properties' do
-        expect { subject.keys.foo }.to raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
This PR removes the usage of the automated SSH keys and reverts back to the question/answer format. For now, any usage of the private key has been discontinued. 