### PR TITLE
Add Metal and Libvirt Content

### DIFF
--- a/data/base/etc/configs/domain.yaml
+++ b/data/base/etc/configs/domain.yaml
@@ -9,11 +9,29 @@ configured_build_interface: '<%= answer.configured_build_interface %>'
 publickey: '<%= answer.root_ssh_key %>'
 role: '<%=answer.role%>'
 
+# PLATFORM: KICKSTART/LIBVIRT
+kernelappendoptions: "console=tty0 console=ttyS1,115200n8"
 
-# PLATFORM: CLOUD
-renderedurl: https://s3-eu-west-1.amazonaws.com/stufranks/rendered/<%=node.platform%>/node/<%=node.name%>
+# UPSTREAM URLS
+yumrepo_buildurl: http://mirror.ox.ac.uk/sites/mirror.centos.org/7/os/x86_64/
+renderedurl: https://s3-eu-west-1.amazonaws.com/stufranks/rendered/<%=node.config.cluster%>/var/rendered/<%=node.platform%>/node/<%=node.name%>
 nodescripturl: <%= config.renderedurl %>/main.sh
 
+# DISK
+disklabel: sda
+disksetup: |
+  clearpart --all --initlabel
+  zerombr
+  bootloader --location=mbr --driveorder=<%= config.disklabel %> --append="$bootloaderappend"
+
+  #Disk partitioning information
+  part /boot --fstype ext4 --size=4096 --asprimary --ondisk <%= config.disklabel %>
+  part pv.01 --size=1 --grow --asprimary --ondisk <%= config.disklabel %>
+  volgroup system pv.01
+  logvol  /  --fstype ext4 --vgname=system  --size=16384 --name=root
+  logvol  /var --fstype ext4 --vgname=system --size=16384 --name=var
+  logvol  /tmp --fstype ext4 --vgname=system --size=1 --grow --name=tmp
+  logvol  swap  --fstype swap --vgname=system  --size=8096  --name=swap1
 
 #
 # NETWORKS

--- a/data/base/etc/configs/domain.yaml
+++ b/data/base/etc/configs/domain.yaml
@@ -14,7 +14,7 @@ kernelappendoptions: "console=tty0 console=ttyS1,115200n8"
 
 # UPSTREAM URLS
 yumrepo_buildurl: http://mirror.ox.ac.uk/sites/mirror.centos.org/7/os/x86_64/
-renderedurl: https://s3-eu-west-1.amazonaws.com/stufranks/rendered/<%=node.config.cluster%>/var/rendered/<%=node.platform%>/node/<%=node.name%>
+renderedurl: https://s3-eu-west-1.amazonaws.com/stufranks/<%=node.config.cluster%>/var/rendered/<%=node.platform%>/node/<%=node.name%>
 nodescripturl: <%= config.renderedurl %>/main.sh
 
 # DISK

--- a/data/base/etc/configs/platforms/kickstart.yaml
+++ b/data/base/etc/configs/platforms/kickstart.yaml
@@ -1,0 +1,2 @@
+disklabel: sda
+kernelappendoptions: "console=tty0 console=ttyS1,115200n8"

--- a/data/base/etc/configs/platforms/libvirt.yaml
+++ b/data/base/etc/configs/platforms/libvirt.yaml
@@ -2,6 +2,7 @@ disklabel: vda
 kernelappendoptions: "console=tty0 console=ttyS0,115200n8"
 
 # VM Settings
+vm_disk_pool: 'local'
 vm_disk_pool_path: '/opt/vm'
 vm_root_disk_size: 80
 

--- a/data/base/etc/configs/platforms/libvirt.yaml
+++ b/data/base/etc/configs/platforms/libvirt.yaml
@@ -1,0 +1,9 @@
+disklabel: vda
+kernelappendoptions: "console=tty0 console=ttyS0,115200n8"
+
+# VM Settings
+vm_disk_pool_path: '/opt/vm'
+vm_root_disk_size: 80
+
+vm_memory: 4
+vm_cpus: 2

--- a/data/base/etc/configs/platforms/vbox.yaml
+++ b/data/base/etc/configs/platforms/vbox.yaml
@@ -1,0 +1,2 @@
+disklabel: vda
+kernelappendoptions: "console=tty0 console=ttyS0,115200n8"

--- a/data/base/lib/templates/content/node/base/main.sh
+++ b/data/base/lib/templates/content/node/base/main.sh
@@ -5,11 +5,6 @@ mkdir -p /root/.ssh
 chmod 600 /root/.ssh
 echo <%= config.publickey %> >> /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
-# This has been commented out until a clearer solution for SSH key generation has been determined
-#cat << EOF > /root/.ssh/id_rsa
-#<%= config.privatekey %>
-#EOF
-#chmod 600 /root/.ssh/id_rsa
 sed -i 's/^PasswordAuthentication.*$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 systemctl restart sshd
 

--- a/data/base/lib/templates/kickstart/node/node.ks
+++ b/data/base/lib/templates/kickstart/node/node.ks
@@ -1,0 +1,80 @@
+#!/bin/bash
+#(c)2017 Alces Software Ltd. HPC Consulting Build Suite
+# vim: set filetype=kickstart :
+
+#MISC
+text
+reboot
+skipx
+install
+
+#SECURITY
+firewall --enabled
+firstboot --disable
+selinux --disabled
+
+#AUTH
+auth  --useshadow  --enablemd5
+#GENERATE with openssl passwd -1 $PASSWD
+rootpw --iscrypted <%= config.root_password %>
+
+#LOCALIZATION
+keyboard uk
+lang en_GB
+timezone  Europe/London
+
+#REPOS
+url --url=<%= node.config.yumrepo_buildurl %>
+
+#DISK
+%include /tmp/disk.part
+
+#PRESCRIPT
+%pre
+set -x -v
+exec 1>/tmp/ks-pre.log 2>&1
+
+DISKFILE=/tmp/disk.part
+bootloaderappend="<%= config.kernelappendoptions %>"
+cat > $DISKFILE << EOF
+<%= config.disksetup %>
+EOF
+%end
+
+#PACKAGES
+%packages --ignoremissing
+
+vim
+emacs
+xauth
+xhost
+xdpyinfo
+xterm
+xclock
+tigervnc-server
+ntpdate
+vconfig
+bridge-utils
+patch
+tcl-devel
+gettext
+wget
+
+%end
+
+#POSTSCRIPTS
+%post --nochroot
+set -x -v
+exec 1>/mnt/sysimage/root/ks-post-nochroot.log 2>&1
+
+ntpdate 0.centos.pool.ntp.org
+
+%end
+%post
+set -x -v
+exec 1>/root/ks-post.log 2>&1
+
+# Example of using rendered Metalware file; this file itself also uses other
+# rendered files.
+curl <%= node.config.nodescripturl %> | /bin/bash -x | tee /tmp/mainscript-default-output
+%end

--- a/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_bios
+++ b/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_bios
@@ -7,7 +7,7 @@ ONTIMEOUT local
 
 LABEL INSTALL
      KERNEL boot/centos7-kernel
-        APPEND initrd=boot/centos7-initrd.img ks=<%= node.renderedurl %>/node.ks network ks.sendmac _ALCES_BASE_HOSTNAME=<%= node.name %> inst.loglevel=debug <%= config.kernelappendoptions %>
+        APPEND initrd=boot/centos7-initrd.img ks=<%= config.renderedurl %>/node.ks network ks.sendmac _ALCES_BASE_HOSTNAME=<%= node.name %> inst.loglevel=debug <%= config.kernelappendoptions %>
         IPAPPEND 2
 
 LABEL local

--- a/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_bios
+++ b/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_bios
@@ -1,0 +1,16 @@
+DEFAULT menu
+PROMPT 0
+MENU TITLE PXE Menu
+TIMEOUT 5
+TOTALTIMEOUT 5
+ONTIMEOUT local
+
+LABEL INSTALL
+     KERNEL boot/centos7-kernel
+        APPEND initrd=boot/centos7-initrd.img ks=<%= node.renderedurl %>/node.ks network ks.sendmac _ALCES_BASE_HOSTNAME=<%= node.name %> inst.loglevel=debug <%= config.kernelappendoptions %>
+        IPAPPEND 2
+
+LABEL local
+     MENU LABEL (local)
+     MENU DEFAULT
+     LOCALBOOT 0

--- a/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_uefi
+++ b/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_uefi
@@ -1,0 +1,9 @@
+set default=0
+set timeout=10
+menuentry 'LOCAL' {
+    exit
+}
+menuentry 'INSTALL' {
+    linuxefi boot/centos7-kernel ks=<%= alces.renderedurl %>/node.ks network ks.sendmac _ALCES_BASE_HOSTNAME=<%= node.name %> <%= config.kernelappendoptions %>
+        initrdefi boot/centos7-initrd.img
+}

--- a/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_uefi
+++ b/data/base/lib/templates/kickstart/node/pxelinux.cfg/pxe_uefi
@@ -4,6 +4,6 @@ menuentry 'LOCAL' {
     exit
 }
 menuentry 'INSTALL' {
-    linuxefi boot/centos7-kernel ks=<%= alces.renderedurl %>/node.ks network ks.sendmac _ALCES_BASE_HOSTNAME=<%= node.name %> <%= config.kernelappendoptions %>
+    linuxefi boot/centos7-kernel ks=<%= config.renderedurl %>/node.ks network ks.sendmac _ALCES_BASE_HOSTNAME=<%= node.name %> <%= config.kernelappendoptions %>
         initrdefi boot/centos7-initrd.img
 }

--- a/data/base/lib/templates/libvirt/node/disk.xml
+++ b/data/base/lib/templates/libvirt/node/disk.xml
@@ -1,0 +1,20 @@
+<volume type='file'>
+  <name><%= node.name %></name>
+  <key><%= node.config.vm_disk_pool %>/<%= node.name %></key>
+  <source>
+  </source>
+  <capacity unit='G'><%= node.config.vm_root_disk_size %></capacity>
+  <target>
+    <path><%= node.config.vm_disk_pool_path %>/<%= node.name %></path>
+    <format type='qcow2'/>
+    <permissions>
+      <mode>0644</mode>
+      <owner>0</owner>
+      <group>0</group>
+    </permissions>
+    <compat>1.1</compat>
+    <features>
+      <lazy_refcounts/>
+    </features>
+  </target>
+</volume>

--- a/data/base/lib/templates/libvirt/node/vm.xml
+++ b/data/base/lib/templates/libvirt/node/vm.xml
@@ -1,0 +1,81 @@
+<domain type='kvm'>
+  <name><%= node.name %></name>
+  <memory unit='GiB'><%= node.config.vm_memory %></memory>
+  <vcpu placement='static'><%= node.config.vm_cpus %></vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-rhel7.0.0'>hvm</type>
+    <boot dev='network'/>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <clock offset='utc'>
+    <timer name='rtc' tickpolicy='catchup'/>
+    <timer name='pit' tickpolicy='delay'/>
+    <timer name='hpet' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <pm>
+    <suspend-to-mem enabled='no'/>
+    <suspend-to-disk enabled='no'/>
+  </pm>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='<%= node.config.vm_disk_pool_path %>/<%= node.name %>'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </disk>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
+    </controller>
+    <% if node.config.networks.network1.defined -%>
+    <interface type='bridge'>
+      <source bridge='<%= config.networks.network1.domain %>'/>
+      <target dev='vnet10'/>
+      <model type='virtio'/>
+      <alias name='net0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </interface>
+    <% end -%>
+    <% if node.config.networks.network2.defined -%>
+    <interface type='bridge'>
+      <source bridge='<%= config.networks.network2.domain %>'/>
+      <target dev='vnet11'/>
+      <model type='virtio'/>
+      <alias name='net0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </interface>
+    <% end -%>
+    <serial type='pty'>
+      <source path='/dev/pts/1'/>
+      <target port='0'/>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/1'>
+      <source path='/dev/pts/1'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <graphics type='vnc' port='5901' autoport='yes' listen='0.0.0.0'>
+      <listen type='address' address='0.0.0.0'/>
+    </graphics>
+    <video>
+      <model type='cirrus' vram='16384' heads='1'/>
+      <alias name='video0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </video>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x10' function='0x0'/>
+    </memballoon>
+  </devices>
+</domain>

--- a/data/example/etc/configs/groups/nodes.yaml
+++ b/data/example/etc/configs/groups/nodes.yaml
@@ -1,0 +1,3 @@
+networks:
+  network1:
+    gateway: <%= nodes.gateway1.config.networks.network1.ip %>


### PR DESCRIPTION
This PR migrates the metal (kickstart) and libvirt files from `metalware-repo-base` across to underware. 

Additionally there is a fix for the gateway setup on the example cluster 
080474f