### PR TITLE
Refactor the cluster commands and implement import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ PATH
       recursive-open-struct
       ruby-progressbar
       rubytree
+      rubyzip
       terminal-table
 
 GEM
@@ -130,6 +131,7 @@ GEM
     rubocop-rspec (1.23.0)
       rubocop (>= 0.52.1)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -35,6 +35,20 @@ global_options:
       Suppress any warnings from being displayed
 
 subcommands:
+  cluster_init: &cluster_init
+    syntax: underware cluster init CLUSTER_IDENTIFIER [options]
+    summary: Create a basic cluster configuration
+    description: >
+      Creates a new cluster with a basic cluster layout. This command will
+      automatically switch to the CLUSTER_IDENTIFIER. This will determine where
+      the configuration is saved.
+
+      Please use the `cluster` command to manage the current cluster.
+    options:
+      - tags: [-b, --bare]
+        description: 'Setup a new cluster without any configuration'
+    action: Commands::Init
+
   configure_domain: &configure_domain
     syntax: underware configure domain [options]
     summary: Configure Underware domain
@@ -195,6 +209,8 @@ commands:
       - tags: ['--delete']
         description: 'Destroy the cluster configuration'
     action: Commands::Cluster
+    subcommands:
+      init: *cluster_init
 
   configure:
     syntax: underware configure [SUB_COMMAND] [options]
@@ -232,20 +248,6 @@ commands:
       - *color_output
       - *platform_option
       - *render_option
-
-  init: &init
-    syntax: underware init CLUSTER_IDENTIFIER [options]
-    summary: Create a basic cluster configuration
-    description: >
-      Creates a new cluster with a basic cluster layout. This command will
-      automatically switch to the CLUSTER_IDENTIFIER. This will determine where
-      the configuration is saved.
-
-      Please use the `cluster` command to manage the current cluster.
-    options:
-      - tags: [-b, --bare]
-        description: 'Setup a new cluster without any configuration'
-    action: Commands::Init
 
   overview:
     syntax: underware overview [options]

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -270,6 +270,11 @@ commands:
       - *platform_option
       - *render_option
 
+  export:
+    syntax: underware export [options]
+    summary: Dump the rendered templates to a zip file
+    action: Commands::Export
+
   overview:
     syntax: underware overview [options]
     summary: Gives an overview of the configured groups

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -35,6 +35,18 @@ global_options:
       Suppress any warnings from being displayed
 
 subcommands:
+  cluster_delete: &cluster_delete
+    syntax: underware cluster delete CLUSTER_IDENTIFIER [options]
+    summary: Deletes the specified cluster and associated files
+    description: >
+      Deletes the configuration files and rendered templates associated
+      with the cluster. It can not delete the current cluster.
+
+
+      Deleting the 'default' cluster will remove all the current configuration.
+      It will still however be recreated as a bare cluster if required.
+    action: Commands::Cluster::Delete
+
   cluster_init: &cluster_init
     syntax: underware cluster init CLUSTER_IDENTIFIER [options]
     summary: Create a basic cluster configuration
@@ -205,11 +217,9 @@ commands:
 
       Calling the command with the `CLUSTER` argument will switch the current
       cluster before listing all the existing clusters as before.
-    options:
-      - tags: ['--delete']
-        description: 'Destroy the cluster configuration'
     action: Commands::Cluster
     subcommands:
+      delete: *cluster_delete
       init: *cluster_init
 
   configure:

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -78,20 +78,20 @@ subcommands:
     syntax: underware configure domain [options]
     summary: Configure Underware domain
     description: >
-      Asks a sequence of questions to configure the domain for this Underware
-      installation. The configuration answers will then be used when rendering
-      templates.
+      General configuration questions about how the cluster should be setup.
+      The configuration answers will then be used when rendering templates.
     action: Commands::Configure::Domain
     options:
       - *configure_answers_option
 
   configure_group: &configure_group
-    syntax: underware configure group GROUP_NAME [NODE_RANGE] [options]
-    summary: Configure a Underware group
+    syntax: underware configure group GROUP [NODE_RANGE] [options]
+    summary: Add or modifies a group of nodes within the cluster
     description: >
-      Asks a sequence of questions to configure a group for this Underware
-      installation. The configuration answers will then be used when rendering
-      templates.
+      Configure a group of nodes within the cluster. The `GROUP` will be
+      automatically created and assigned an index. The `NODE_RANGE` will add
+      the nodes to the group (see below). The answers will be used when rendering
+      templates specific to the group/nodes.
 
 
       The NODE_RANGE specifies the nodes to be added to the group. It supports
@@ -116,12 +116,15 @@ subcommands:
         description: 'A comma separated list of additional secondary groups'
 
   configure_node: &configure_node
-    syntax: underware configure node NODE_NAME [options]
+    syntax: underware configure node NODE [options]
     summary: Configure a Underware node
     description: >
-      Asks a sequence of questions to configure a node for this Underware
-      installation. The configuration answers will then be used when rendering
-      templates.
+      Additional qustions or overrides about a particular node. This will update
+      the configuration for this node only.
+
+      This allows for a single node to be configured differently within a group.
+      If the `NODE` does not exist, it is automatically assigned to the orphan
+      group.
     action: Commands::Configure::Node
     options:
       - *configure_answers_option
@@ -231,8 +234,9 @@ commands:
 
   configure:
     syntax: underware configure [SUB_COMMAND] [options]
-    summary: Configure different aspects of this Underware installation
+    summary: Manage the cluster and node configurations
     subcommands:
+      cluster: *configure_domain
       domain: *configure_domain
       group: *configure_group
       node: *configure_node

--- a/lib/underware/cli_helper/config.yaml
+++ b/lib/underware/cli_helper/config.yaml
@@ -41,10 +41,6 @@ subcommands:
     description: >
       Deletes the configuration files and rendered templates associated
       with the cluster. It can not delete the current cluster.
-
-
-      Deleting the 'default' cluster will remove all the current configuration.
-      It will still however be recreated as a bare cluster if required.
     action: Commands::Cluster::Delete
 
   cluster_init: &cluster_init
@@ -60,6 +56,23 @@ subcommands:
       - tags: [-b, --bare]
         description: 'Setup a new cluster without any configuration'
     action: Commands::Init
+
+  cluster_list: &cluster_list
+    syntax: underware cluster list [options]
+    summary: List the current and available clusters
+    description: >
+      Returns a list of all available clusters. The current cluster is marked
+      by an asterisks ('*')
+    action: Commands::Cluster
+
+  cluster_switch: &cluster_switch
+    syntax: underware cluster switch CLUSTER_IDENTIFIER [options]
+    summary: Change the current cluster
+    description: >
+      Change the current cluster to CLUSTER_IDENTIFIER. The cluster must exist
+      before it can be switched to. Use the `cluster init` command to create
+      a new cluster
+    action: Commands::Cluster
 
   configure_domain: &configure_domain
     syntax: underware configure domain [options]
@@ -209,18 +222,12 @@ subcommands:
 commands:
   cluster:
     syntax: underware cluster [CLUSTER] [options]
-    summary: List, switch, and delete cluster configurations
-    description: >
-      If called without any arguments, the existing clusters are listed with
-      the current cluster highlighted with an asterisk.
-
-
-      Calling the command with the `CLUSTER` argument will switch the current
-      cluster before listing all the existing clusters as before.
-    action: Commands::Cluster
+    summary: Initialize, list, switch, and delete cluster configurations
     subcommands:
       delete: *cluster_delete
+      list: *cluster_list
       init: *cluster_init
+      switch: *cluster_switch
 
   configure:
     syntax: underware configure [SUB_COMMAND] [options]

--- a/lib/underware/commands/cluster.rb
+++ b/lib/underware/commands/cluster.rb
@@ -43,20 +43,9 @@ module Underware
         # Load the current_cluster from the config to ensure the default
         # has been created (if required)
         __config__.current_cluster
-        options.delete ? run_delete : run_normal
-      end
-
-      def run_normal
         switch_cluster if cluster_input
         missing_check
         list_clusters
-      end
-
-      def run_delete
-        cluster = cluster_input || __config__.current_cluster
-        error_if_deleting_current_cluster(cluster)
-        error_if_cluster_missing(cluster, action: 'delete')
-        delete_cluster(cluster)
       end
 
       def missing_check
@@ -104,6 +93,15 @@ module Underware
           Can not delete the current cluster, please switch cluster and run:
           '#{Underware::APP_NAME} cluster --delete #{cluster}'
         ERROR
+      end
+
+      class Delete < Cluster
+        def run
+          cluster = cluster_input || __config__.current_cluster
+          error_if_deleting_current_cluster(cluster)
+          error_if_cluster_missing(cluster, action: 'delete')
+          delete_cluster(cluster)
+        end
       end
     end
   end

--- a/lib/underware/commands/export.rb
+++ b/lib/underware/commands/export.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2019 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Underware.
+#
+# Alces Underware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Underware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Underware, please visit:
+# https://github.com/alces-software/underware
+#==============================================================================
+
+require 'pathname'
+require 'zip'
+
+module Underware
+  module Commands
+    class Export < CommandHelpers::BaseCommand
+      def run
+        paths = DataPath.cluster(CommandConfig.load.current_cluster)
+        Zip::File.open(generate_export_path, Zip::File::CREATE) do |zip|
+          Dir.glob(paths.template('**/*'))
+             .map { |p| Pathname.new(p) }
+             .reject(&:directory?)
+             .each do |path|
+            zip.add(path.relative_path_from(Pathname.new(paths.template)), path)
+          end
+          puts "Exported: #{zip.name}"
+        end
+      end
+
+      private
+
+      def generate_export_path
+        File.expand_path("~/underware-#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}.zip")
+      end
+    end
+  end
+end
+

--- a/underware.gemspec
+++ b/underware.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'recursive-open-struct'
   spec.add_runtime_dependency 'ruby-progressbar'
   spec.add_runtime_dependency 'rubytree'
+  spec.add_runtime_dependency 'rubyzip'
   spec.add_runtime_dependency 'terminal-table'
 
   # Test dependencies.


### PR DESCRIPTION
The `init` and `cluster` commands have been reorganised as `cluster init/list/switch/delete`. This is done with a couple of short cuts as the invocation may be refactored anyway.

The `export` command has also been implemented. It dumps the rendered directory into the users home.

fixes #88 fixes #89