### PR TITLE
Add cluster information to a node's tags

### DIFF
--- a/data/base/lib/templates/aws/node/__name__.yaml
+++ b/data/base/lib/templates/aws/node/__name__.yaml
@@ -74,7 +74,7 @@ Resources:
           Value: '<%=name%>'
         -
           Key: 'flightcluster'
-          Value: <%=name%>
+          Value: '<%=config.cluster%>'
 <% end -%>
 <% end -%>
 
@@ -103,7 +103,7 @@ Resources:
           Value: '<%=name%>'
         -
           Key: 'flightcluster'
-          Value: <%=name%>
+          Value: '<%=config.cluster%>'
       UserData:
         Fn::Base64:
           Fn::Join:


### PR DESCRIPTION
Add a little more information to aws instances to begin to facilitate cost tracking

Will need more info eventually, to be able to break down on a machine/deployment basis but this works as a first pass